### PR TITLE
Resolve some tech debt

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,3 +1,3 @@
 # Minimum supported Rust version. Should be consistent with CI and mentions
 # in crate READMEs.
-msrv = "1.60"
+msrv = "1.65"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 env:
-  msrv: 1.60.0
+  msrv: 1.65.0
   nightly: nightly-2022-09-22
   binaryen: version_110
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/slowli/tardigrade/workflows/CI/badge.svg?branch=main)](https://github.com/slowli/tardigrade/actions)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%2FApache--2.0-blue)](https://github.com/slowli/tardigrade#license)
-![rust 1.60+ required](https://img.shields.io/badge/rust-1.60+-blue.svg?label=Required%20Rust)
+![rust 1.65+ required](https://img.shields.io/badge/rust-1.65+-blue.svg?label=Required%20Rust)
 
 **Documentation:**
 [![crate docs (main)](https://img.shields.io/badge/main-yellow.svg?label=docs)](https://slowli.github.io/tardigrade/tardigrade/)

--- a/crates/derive/README.md
+++ b/crates/derive/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/slowli/tardigrade/workflows/CI/badge.svg?branch=main)](https://github.com/slowli/tardigrade/actions)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%2FApache--2.0-blue)](https://github.com/slowli/tardigrade#license)
-![rust 1.60+ required](https://img.shields.io/badge/rust-1.60+-blue.svg?label=Required%20Rust)
+![rust 1.65+ required](https://img.shields.io/badge/rust-1.65+-blue.svg?label=Required%20Rust)
 
 This crate provides procedural macros for [`tardigrade`] allowing
 to simplify workflow definition.

--- a/crates/rt/Cargo.toml
+++ b/crates/rt/Cargo.toml
@@ -48,6 +48,9 @@ features = ["receiver"]
 [dev-dependencies]
 assert_matches = "1.5.0"
 async-std = { version = "1.12.0", features = ["attributes"] }
-#mimicry = "0.1.0"
-mimicry = { path = "../../../mimicry" }
 version-sync = "0.9.4"
+
+[dev-dependencies.mimicry]
+version = "0.1.0"
+git = "https://github.com/slowli/mimicry.git"
+rev = "87abe3031032d3465f2e0172c96b68cd16fcf9f9"

--- a/crates/rt/Cargo.toml
+++ b/crates/rt/Cargo.toml
@@ -22,13 +22,12 @@ once_cell = "1.13.0"
 pin-project-lite = "0.2.9"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
-wasmtime = "1.0.1"
+tracing = "0.1.37"
+wasmtime = "3.0.0"
 
 ## Standalone optional dependencies
 # Implements the scheduler trait based on `async-io` / `async-std` runtime.
 async-io = { version = "1.7.0", optional = true }
-# Enables tracing during workflow execution.
-tracing = "0.1.37"
 
 tardigrade = { version = "0.1.0", path = "../.." }
 

--- a/crates/rt/Cargo.toml
+++ b/crates/rt/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1.0.57"
 async-trait = "0.1.57"
 base64 = "0.13.0"
 chrono = { version = "0.4.22", features = ["serde"] }
-flate2 = "1.0.24" # TODO: make optional? (+ expose workflow memory)
+flate2 = "1.0.24"
 futures = "0.3.21"
 leb128 = "0.2.5"
 once_cell = "1.13.0"
@@ -31,9 +31,9 @@ async-io = { version = "1.7.0", optional = true }
 
 tardigrade = { version = "0.1.0", path = "../.." }
 
-# TODO: make optional together with the `test` module?
 [dependencies.externref]
 version = "0.1.0"
+optional = true
 git = "https://github.com/slowli/externref.git"
 rev = "36f978748b27d1621e6a565317859b00f99f5e8a"
 features = ["processor"]
@@ -53,3 +53,8 @@ version-sync = "0.9.4"
 version = "0.1.0"
 git = "https://github.com/slowli/mimicry.git"
 rev = "87abe3031032d3465f2e0172c96b68cd16fcf9f9"
+
+[features]
+default = []
+# Enables the `test` module with test-related helpers.
+test = ["externref"]

--- a/crates/rt/Cargo.toml
+++ b/crates/rt/Cargo.toml
@@ -48,5 +48,6 @@ features = ["receiver"]
 [dev-dependencies]
 assert_matches = "1.5.0"
 async-std = { version = "1.12.0", features = ["attributes"] }
-mimicry = "0.1.0"
+#mimicry = "0.1.0"
+mimicry = { path = "../../../mimicry" }
 version-sync = "0.9.4"

--- a/crates/rt/README.md
+++ b/crates/rt/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/slowli/tardigrade/workflows/CI/badge.svg?branch=main)](https://github.com/slowli/tardigrade/actions)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%2FApache--2.0-blue)](https://github.com/slowli/tardigrade#license)
-![rust 1.60+ required](https://img.shields.io/badge/rust-1.60+-blue.svg?label=Required%20Rust)
+![rust 1.65+ required](https://img.shields.io/badge/rust-1.65+-blue.svg?label=Required%20Rust)
 
 **Documentation:**
 [![crate docs (main)](https://img.shields.io/badge/main-yellow.svg?label=docs)](https://slowli.github.io/tardigrade/tardigrade_rt/)

--- a/crates/rt/src/data/helpers.rs
+++ b/crates/rt/src/data/helpers.rs
@@ -21,14 +21,6 @@ use tardigrade::{
     ChannelId, TaskId, TimerId, WakerId, WorkflowId,
 };
 
-/// Unique reference to a channel within a workflow.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub(super) struct ChannelRef {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub workflow_id: Option<WorkflowId>,
-    pub name: String,
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(super) enum HostResource {
@@ -257,18 +249,11 @@ impl CurrentExecution {
         });
     }
 
-    pub fn push_channel_closure(
-        &mut self,
-        kind: ChannelKind,
-        channel_id: ChannelId,
-        remaining_alias_count: usize,
-    ) {
+    pub fn push_channel_closure(&mut self, kind: ChannelKind, channel_id: ChannelId) {
         self.push_event(ChannelEvent {
             kind: match kind {
                 ChannelKind::Inbound => ChannelEventKind::InboundChannelClosed,
-                ChannelKind::Outbound => ChannelEventKind::OutboundChannelClosed {
-                    remaining_alias_count,
-                },
+                ChannelKind::Outbound => ChannelEventKind::OutboundChannelClosed,
             },
             channel_id,
         });

--- a/crates/rt/src/data/mod.rs
+++ b/crates/rt/src/data/mod.rs
@@ -25,7 +25,7 @@ pub(crate) use self::{
     spawn::SpawnFunctions,
 };
 pub use self::{
-    channel::{InboundChannelState, OutboundChannelState},
+    channel::{ChannelMapping, InboundChannelState, OutboundChannelState},
     spawn::ChildWorkflowState,
     task::TaskState,
     time::TimerState,
@@ -134,12 +134,12 @@ impl<'a> WorkflowData<'a> {
         child_id: Option<WorkflowId>,
         name: &str,
     ) -> ExternRef {
-        let channel_ids = if let Some(child_id) = child_id {
+        let mapping = if let Some(child_id) = child_id {
             &self.persisted.child_workflows[&child_id].channels
         } else {
             &self.persisted.channels.mapping
         };
-        let channel_id = channel_ids.inbound[name];
+        let channel_id = mapping.inbound_id(name).unwrap();
         HostResource::InboundChannel(channel_id).into_ref()
     }
 
@@ -149,12 +149,12 @@ impl<'a> WorkflowData<'a> {
         child_id: Option<WorkflowId>,
         name: &str,
     ) -> ExternRef {
-        let channel_ids = if let Some(child_id) = child_id {
+        let mapping = if let Some(child_id) = child_id {
             &self.persisted.child_workflows[&child_id].channels
         } else {
             &self.persisted.channels.mapping
         };
-        let channel_id = channel_ids.outbound[name];
+        let channel_id = mapping.outbound_id(name).unwrap();
         HostResource::OutboundChannel(channel_id).into_ref()
     }
 

--- a/crates/rt/src/data/mod.rs
+++ b/crates/rt/src/data/mod.rs
@@ -25,8 +25,8 @@ pub(crate) use self::{
     spawn::SpawnFunctions,
 };
 pub use self::{
-    channel::{ChannelMapping, InboundChannelState, OutboundChannelState},
-    spawn::ChildWorkflowState,
+    channel::{Channels, InboundChannelState, OutboundChannelState},
+    spawn::ChildWorkflow,
     task::TaskState,
     time::TimerState,
 };
@@ -34,7 +34,7 @@ pub use self::{
 use self::{
     channel::ChannelStates,
     helpers::{CurrentExecution, HostResource},
-    spawn::ChildWorkflowStubs,
+    spawn::{ChildWorkflowState, ChildWorkflowStubs},
     task::TaskQueue,
     time::Timers,
 };
@@ -134,12 +134,12 @@ impl<'a> WorkflowData<'a> {
         child_id: Option<WorkflowId>,
         name: &str,
     ) -> ExternRef {
-        let mapping = if let Some(child_id) = child_id {
-            &self.persisted.child_workflows[&child_id].channels
+        let channels = if let Some(child_id) = child_id {
+            self.persisted.child_workflow(child_id).unwrap().channels()
         } else {
-            &self.persisted.channels.mapping
+            self.persisted.channels()
         };
-        let channel_id = mapping.inbound_id(name).unwrap();
+        let channel_id = channels.receiver_id(name).unwrap();
         HostResource::InboundChannel(channel_id).into_ref()
     }
 
@@ -149,12 +149,12 @@ impl<'a> WorkflowData<'a> {
         child_id: Option<WorkflowId>,
         name: &str,
     ) -> ExternRef {
-        let mapping = if let Some(child_id) = child_id {
-            &self.persisted.child_workflows[&child_id].channels
+        let channels = if let Some(child_id) = child_id {
+            self.persisted.child_workflow(child_id).unwrap().channels()
         } else {
-            &self.persisted.channels.mapping
+            self.persisted.channels()
         };
-        let channel_id = mapping.outbound_id(name).unwrap();
+        let channel_id = channels.sender_id(name).unwrap();
         HostResource::OutboundChannel(channel_id).into_ref()
     }
 

--- a/crates/rt/src/data/persistence.rs
+++ b/crates/rt/src/data/persistence.rs
@@ -84,10 +84,10 @@ impl OutboundChannelState {
 
 impl ChannelStates {
     fn check_on_restore(&self, interface: &Interface) -> anyhow::Result<()> {
-        for name in self.mapping.inbound.keys() {
+        for (name, _) in self.mapping.inbound_ids() {
             InboundChannelState::check_on_restore(interface, name)?;
         }
-        for name in self.mapping.outbound.keys() {
+        for (name, _) in self.mapping.outbound_ids() {
             OutboundChannelState::check_on_restore(interface, name)?;
         }
         Ok(())
@@ -97,9 +97,7 @@ impl ChannelStates {
 impl PersistedWorkflowData {
     pub(super) fn new(interface: &Interface, channel_ids: ChannelIds, now: DateTime<Utc>) -> Self {
         Self {
-            channels: ChannelStates::new(channel_ids, |name| {
-                interface.outbound_channel(name).unwrap().capacity
-            }),
+            channels: ChannelStates::new(channel_ids, interface),
             timers: Timers::new(now),
             tasks: HashMap::new(),
             child_workflows: HashMap::new(),

--- a/crates/rt/src/data/persistence.rs
+++ b/crates/rt/src/data/persistence.rs
@@ -1,6 +1,6 @@
 //! Persistence for `State`.
 
-use anyhow::{anyhow, ensure};
+use anyhow::anyhow;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use wasmtime::{Store, Val};
@@ -84,30 +84,12 @@ impl OutboundChannelState {
 
 impl ChannelStates {
     fn check_on_restore(&self, interface: &Interface) -> anyhow::Result<()> {
-        let inbound_channels_len = interface.inbound_channels().len();
-        ensure!(
-            inbound_channels_len == self.inbound.len(),
-            "mismatch between number of inbound channels in workflow interface ({}) \
-             and in persisted state ({})",
-            inbound_channels_len,
-            self.inbound.len()
-        );
         for name in self.mapping.inbound.keys() {
             InboundChannelState::check_on_restore(interface, name)?;
         }
-
-        let outbound_channels_len = interface.outbound_channels().len();
-        ensure!(
-            outbound_channels_len == self.outbound.len(),
-            "mismatch between number of outbound channels in workflow interface ({}) \
-             and in persisted state ({})",
-            outbound_channels_len,
-            self.outbound.len()
-        );
         for name in self.mapping.outbound.keys() {
             OutboundChannelState::check_on_restore(interface, name)?;
         }
-
         Ok(())
     }
 }

--- a/crates/rt/src/data/persistence.rs
+++ b/crates/rt/src/data/persistence.rs
@@ -13,12 +13,12 @@ use super::{
     spawn::ChildWorkflowStubs,
     task::TaskQueue,
     time::Timers,
-    PersistedWorkflowData, WorkflowCounters, WorkflowData,
+    PersistedWorkflowData, WorkflowData,
 };
 use crate::{module::Services, workflow::ChannelIds};
 use tardigrade::{
     interface::{ChannelKind, Interface},
-    WorkflowId,
+    ChannelId,
 };
 
 /// Error persisting a workflow.
@@ -30,11 +30,8 @@ pub(crate) enum PersistError {
     PendingMessage {
         /// Kind of the channel involved.
         channel_kind: ChannelKind,
-        /// Name of the channel with the message.
-        channel_name: String,
-        /// ID of the remote workflow that the channel is attached to, or `None` if the channel
-        /// is local.
-        workflow_id: Option<WorkflowId>,
+        /// ID of the channel with the message.
+        channel_id: ChannelId,
     },
 }
 
@@ -46,18 +43,12 @@ impl fmt::Display for PersistError {
 
             Self::PendingMessage {
                 channel_kind,
-                channel_name,
-                workflow_id,
+                channel_id,
             } => {
                 write!(
                     formatter,
-                    "there is an non-flushed {} message on channel `{}`",
-                    channel_kind, channel_name
-                )?;
-                if let Some(id) = workflow_id {
-                    write!(formatter, " for workflow {}", id)?;
-                }
-                Ok(())
+                    "there is an non-flushed {channel_kind} message on channel {channel_id}"
+                )
             }
         }
     }
@@ -101,7 +92,7 @@ impl ChannelStates {
             inbound_channels_len,
             self.inbound.len()
         );
-        for name in self.inbound.keys() {
+        for name in self.mapping.inbound.keys() {
             InboundChannelState::check_on_restore(interface, name)?;
         }
 
@@ -113,7 +104,7 @@ impl ChannelStates {
             outbound_channels_len,
             self.outbound.len()
         );
-        for name in self.outbound.keys() {
+        for name in self.mapping.outbound.keys() {
             OutboundChannelState::check_on_restore(interface, name)?;
         }
 
@@ -122,7 +113,7 @@ impl ChannelStates {
 }
 
 impl PersistedWorkflowData {
-    pub(super) fn new(interface: &Interface, channel_ids: &ChannelIds, now: DateTime<Utc>) -> Self {
+    pub(super) fn new(interface: &Interface, channel_ids: ChannelIds, now: DateTime<Utc>) -> Self {
         Self {
             channels: ChannelStates::new(channel_ids, |name| {
                 interface.outbound_channel(name).unwrap().capacity
@@ -145,7 +136,6 @@ impl PersistedWorkflowData {
             exports: None,
             persisted: self,
             services,
-            counters: WorkflowCounters::default(),
             current_execution: None,
             task_queue: TaskQueue::default(),
             current_wakeup_cause: None,
@@ -160,21 +150,19 @@ impl WorkflowData<'_> {
             return Err(PersistError::PendingTask);
         }
 
-        for (workflow_id, name, state) in self.persisted.inbound_channels() {
+        for (channel_id, state) in self.persisted.inbound_channels() {
             if state.pending_message.is_some() {
                 return Err(PersistError::PendingMessage {
                     channel_kind: ChannelKind::Inbound,
-                    channel_name: name.to_owned(),
-                    workflow_id,
+                    channel_id,
                 });
             }
         }
-        for (workflow_id, name, state) in self.persisted.outbound_channels() {
+        for (channel_id, state) in self.persisted.outbound_channels() {
             if !state.messages.is_empty() {
                 return Err(PersistError::PendingMessage {
                     channel_kind: ChannelKind::Outbound,
-                    channel_name: name.to_owned(),
-                    workflow_id,
+                    channel_id,
                 });
             }
         }

--- a/crates/rt/src/data/persistence.rs
+++ b/crates/rt/src/data/persistence.rs
@@ -84,10 +84,10 @@ impl OutboundChannelState {
 
 impl ChannelStates {
     fn check_on_restore(&self, interface: &Interface) -> anyhow::Result<()> {
-        for (name, _) in self.mapping.inbound_ids() {
+        for name in self.mapping.receiver_names() {
             InboundChannelState::check_on_restore(interface, name)?;
         }
-        for (name, _) in self.mapping.outbound_ids() {
+        for name in self.mapping.sender_names() {
             OutboundChannelState::check_on_restore(interface, name)?;
         }
         Ok(())

--- a/crates/rt/src/data/spawn.rs
+++ b/crates/rt/src/data/spawn.rs
@@ -1,8 +1,9 @@
 //! Spawning workflows.
 
+use anyhow::{anyhow, Context};
 use serde::{Deserialize, Serialize};
 use tracing::field;
-use wasmtime::{AsContextMut, ExternRef, StoreContextMut, Trap};
+use wasmtime::{AsContextMut, ExternRef, StoreContextMut};
 
 use std::{
     collections::{HashMap, HashSet},
@@ -193,20 +194,20 @@ impl WorkflowData<'_> {
         &self,
         definition_id: &str,
         channels: &ChannelsConfig<ChannelId>,
-    ) -> Result<(), Trap> {
+    ) -> anyhow::Result<()> {
         let workflows = self.services.workflows.as_deref();
         let interface = workflows.and_then(|workflows| workflows.interface(definition_id));
         if let Some(interface) = interface {
             for (name, _) in interface.inbound_channels() {
                 if !channels.inbound.contains_key(name) {
-                    let message = format!("missing handle for inbound channel `{}`", name);
-                    return Err(Trap::new(message));
+                    let err = anyhow!("missing handle for inbound channel `{name}`");
+                    return Err(err);
                 }
             }
             for (name, _) in interface.outbound_channels() {
                 if !channels.outbound.contains_key(name) {
-                    let message = format!("missing handle for outbound channel `{}`", name);
-                    return Err(Trap::new(message));
+                    let err = anyhow!("missing handle for outbound channel `{name}`");
+                    return Err(err);
                 }
             }
 
@@ -220,10 +221,7 @@ impl WorkflowData<'_> {
             }
             Ok(())
         } else {
-            Err(Trap::new(format!(
-                "workflow with ID `{}` is not defined",
-                definition_id
-            )))
+            Err(anyhow!("workflow with ID `{definition_id}` is not defined"))
         }
     }
 
@@ -231,7 +229,7 @@ impl WorkflowData<'_> {
         interface: &Interface,
         channels: &ChannelsConfig<ChannelId>,
         channel_kind: ChannelKind,
-    ) -> Trap {
+    ) -> anyhow::Error {
         use std::fmt::Write as _;
 
         let (closure_in, closure_out);
@@ -254,7 +252,7 @@ impl WorkflowData<'_> {
             });
         debug_assert!(!extra_handles.is_empty());
         extra_handles.truncate(extra_handles.len() - 2);
-        Trap::new(format!("extra {} handles: {}", channel_kind, extra_handles))
+        anyhow!("extra {channel_kind} handles: {extra_handles}")
     }
 
     #[tracing::instrument(skip(args), ret, err, fields(args.len = args.len()))]
@@ -263,12 +261,12 @@ impl WorkflowData<'_> {
         definition_id: &str,
         args: Vec<u8>,
         channels: &ChannelsConfig<ChannelId>,
-    ) -> Result<WorkflowId, Trap> {
+    ) -> anyhow::Result<WorkflowId> {
         let workflows = self
             .services
             .workflows
             .as_deref_mut()
-            .ok_or_else(|| Trap::new("no capability to spawn workflows"))?;
+            .ok_or_else(|| anyhow!("no capability to spawn workflows"))?;
         let stub_id = self.persisted.child_workflow_stubs.create();
         workflows.stash_workflow(stub_id, definition_id, args, channels.clone());
 
@@ -283,11 +281,11 @@ impl WorkflowData<'_> {
         &mut self,
         stub_id: WorkflowId,
         cx: &mut WasmContext,
-    ) -> Result<PollStub, Trap> {
+    ) -> anyhow::Result<PollStub> {
         let stubs = &mut self.persisted.child_workflow_stubs.stubs;
         let stub = stubs
             .get(&stub_id)
-            .ok_or_else(|| Trap::new(format!("stub {stub_id} polled after completion")))?;
+            .ok_or_else(|| anyhow!("stub {stub_id} polled after completion"))?;
         let poll_result = stub.result.clone();
         if poll_result.is_ready() {
             // We don't want to create aliased workflow resources; thus, we prevent repeated
@@ -368,12 +366,12 @@ impl SpawnFunctions {
         ctx: &mut StoreContextMut<'_, WorkflowData>,
         result: Result<(), HostError>,
         error_ptr: u32,
-    ) -> Result<(), Trap> {
+    ) -> anyhow::Result<()> {
         let memory = ctx.data().exports().memory;
         let result_abi = result.into_wasm(&mut WasmAllocator::new(ctx.as_context_mut()))?;
         memory
             .write(ctx, error_ptr as usize, &result_abi.to_le_bytes())
-            .map_err(|err| Trap::new(format!("cannot write to WASM memory: {}", err)))
+            .context("cannot write to WASM memory")
     }
 
     #[tracing::instrument(level = "debug", skip_all, err, fields(id, interface.is_some))]
@@ -381,7 +379,7 @@ impl SpawnFunctions {
         ctx: StoreContextMut<'_, WorkflowData>,
         id_ptr: u32,
         id_len: u32,
-    ) -> Result<i64, Trap> {
+    ) -> anyhow::Result<i64> {
         let memory = ctx.data().exports().memory;
         let id = utils::copy_string_from_wasm(&ctx, &memory, id_ptr, id_len)?;
         tracing::Span::current().record("id", &id);
@@ -412,12 +410,13 @@ impl SpawnFunctions {
         name_ptr: u32,
         name_len: u32,
         is_closed: i32,
-    ) -> Result<(), Trap> {
-        let channel_kind = ChannelKind::try_from_wasm(channel_kind).map_err(Trap::new)?;
+    ) -> anyhow::Result<()> {
+        let channel_kind =
+            ChannelKind::try_from_wasm(channel_kind).context("cannot parse channel kind")?;
         let channel_config = match is_closed {
             0 => ChannelSpawnConfig::New,
             1 => ChannelSpawnConfig::Closed,
-            _ => return Err(Trap::new("invalid `is_closed` value; expected 0 or 1")),
+            _ => return Err(anyhow!("invalid `is_closed` value; expected 0 or 1")),
         };
         let memory = ctx.data().exports().memory;
         let name = utils::copy_string_from_wasm(&ctx, &memory, name_ptr, name_len)?;
@@ -448,7 +447,7 @@ impl SpawnFunctions {
         name_ptr: u32,
         name_len: u32,
         sender: Option<ExternRef>,
-    ) -> Result<(), Trap> {
+    ) -> anyhow::Result<()> {
         let channel_ref = HostResource::from_ref(sender.as_ref())?.as_outbound_channel()?;
         let channel_state = ctx.data().persisted.outbound_channel(channel_ref);
         let channel_id = channel_state.unwrap().id();
@@ -476,7 +475,7 @@ impl SpawnFunctions {
         args_ptr: u32,
         args_len: u32,
         handles: Option<ExternRef>,
-    ) -> Result<Option<ExternRef>, Trap> {
+    ) -> anyhow::Result<Option<ExternRef>> {
         let memory = ctx.data().exports().memory;
         let id = utils::copy_string_from_wasm(&ctx, &memory, id_ptr, id_len)?;
         let args = utils::copy_bytes_from_wasm(&ctx, &memory, args_ptr, args_len)?;
@@ -499,7 +498,7 @@ impl SpawnFunctions {
         stub: Option<ExternRef>,
         poll_cx: WasmContextPtr,
         error_ptr: u32,
-    ) -> Result<Option<ExternRef>, Trap> {
+    ) -> anyhow::Result<Option<ExternRef>> {
         let stub_id = HostResource::from_ref(stub.as_ref())?.as_workflow_stub()?;
         tracing::Span::current().record("stub_id", stub_id);
 
@@ -523,7 +522,7 @@ impl SpawnFunctions {
         mut ctx: StoreContextMut<'_, WorkflowData>,
         workflow: Option<ExternRef>,
         poll_cx: WasmContextPtr,
-    ) -> Result<i64, Trap> {
+    ) -> anyhow::Result<i64> {
         let workflow_id = HostResource::from_ref(workflow.as_ref())?.as_workflow()?;
         tracing::Span::current().record("workflow_id", workflow_id);
 
@@ -541,7 +540,7 @@ impl SpawnFunctions {
     pub fn completion_error(
         ctx: StoreContextMut<'_, WorkflowData>,
         workflow: Option<ExternRef>,
-    ) -> Result<i64, Trap> {
+    ) -> anyhow::Result<i64> {
         let workflow_id = HostResource::from_ref(workflow.as_ref())?.as_workflow()?;
         let maybe_err = ctx
             .data()

--- a/crates/rt/src/data/spawn.rs
+++ b/crates/rt/src/data/spawn.rs
@@ -435,15 +435,13 @@ impl SpawnFunctions {
         name_len: u32,
         sender: Option<ExternRef>,
     ) -> anyhow::Result<()> {
-        let channel_ref = HostResource::from_ref(sender.as_ref())?.as_outbound_channel()?;
-        let channel_state = ctx.data().persisted.outbound_channel(channel_ref);
-        let channel_id = channel_state.unwrap().id();
+        let channel_id = HostResource::from_ref(sender.as_ref())?.as_outbound_channel()?;
         let memory = ctx.data().exports().memory;
         let name = utils::copy_string_from_wasm(&ctx, &memory, name_ptr, name_len)?;
 
         tracing::Span::current()
             .record("name", &name)
-            .record("sender", field::debug(channel_ref));
+            .record("sender", channel_id);
 
         let handles = HostResource::from_ref(handles.as_ref())?.as_channel_handles()?;
         let mut handles = handles.inner.lock().unwrap();

--- a/crates/rt/src/data/tests/mod.rs
+++ b/crates/rt/src/data/tests/mod.rs
@@ -15,12 +15,12 @@ mod spawn;
 
 use super::*;
 use crate::{
+    mock_scheduler::MockScheduler,
     module::{ExportsMock, MockPollFn, WorkflowEngine, WorkflowModule},
     receipt::{
         ChannelEvent, ChannelEventKind, Event, ExecutedFunction, Execution, ExecutionError,
         Receipt, ResourceEventKind, ResourceId,
     },
-    test::MockScheduler,
     utils::{copy_string_from_wasm, decode_string, WasmAllocator},
     workflow::{PersistedWorkflow, Workflow},
 };

--- a/crates/rt/src/data/tests/mod.rs
+++ b/crates/rt/src/data/tests/mod.rs
@@ -166,8 +166,8 @@ fn starting_workflow() {
     );
     assert_eq!(execution.events.len(), 1);
 
-    let mapping = workflow.data().persisted.channel_mapping();
-    let orders_id = mapping.inbound_id("orders").unwrap();
+    let mapping = workflow.data().persisted.channels();
+    let orders_id = mapping.receiver_id("orders").unwrap();
     assert_matches!(
         &execution.events[0],
         Event::Channel(ChannelEvent {
@@ -180,8 +180,8 @@ fn starting_workflow() {
 }
 
 fn push_message_and_tick(workflow: &mut Workflow<'_>) -> Result<Receipt, ExecutionError> {
-    let mapping = workflow.data().persisted.channel_mapping();
-    let orders_id = mapping.inbound_id("orders").unwrap();
+    let mapping = workflow.data().persisted.channels();
+    let orders_id = mapping.receiver_id("orders").unwrap();
     workflow
         .data_mut()
         .persisted
@@ -216,11 +216,11 @@ fn receiving_inbound_message() {
     assert_inbound_message_receipt(&workflow, &receipt);
 
     let messages = workflow.data_mut().drain_messages();
-    let mapping = workflow.data().persisted.channel_mapping();
-    let traces_id = mapping.outbound_id("traces").unwrap();
+    let mapping = workflow.data().persisted.channels();
+    let traces_id = mapping.sender_id("traces").unwrap();
     assert_eq!(messages[&traces_id].len(), 1);
     assert_eq!(messages[&traces_id][0].as_ref(), b"trace #1");
-    let events_id = mapping.outbound_id("events").unwrap();
+    let events_id = mapping.sender_id("events").unwrap();
     assert_eq!(messages[&events_id].len(), 1);
     assert_eq!(messages[&events_id][0].as_ref(), b"event #1");
 
@@ -237,10 +237,10 @@ fn receiving_inbound_message() {
 }
 
 fn assert_inbound_message_receipt(workflow: &Workflow<'_>, receipt: &Receipt) {
-    let mapping = &workflow.data().persisted.channels.mapping;
-    let orders_id = mapping.inbound_id("orders").unwrap();
-    let events_id = mapping.outbound_id("events").unwrap();
-    let traces_id = mapping.outbound_id("traces").unwrap();
+    let mapping = workflow.data().persisted.channels();
+    let orders_id = mapping.receiver_id("orders").unwrap();
+    let events_id = mapping.sender_id("events").unwrap();
+    let traces_id = mapping.sender_id("traces").unwrap();
 
     assert_eq!(receipt.executions().len(), 2);
     assert_matches!(

--- a/crates/rt/src/data/tests/spawn.rs
+++ b/crates/rt/src/data/tests/spawn.rs
@@ -225,8 +225,8 @@ fn spawning_child_workflow() {
     let mut children: Vec<_> = workflow.data().persisted.child_workflows().collect();
     assert_eq!(children.len(), 1);
     let (_, child) = children.pop().unwrap();
-    let commands_id = child.channels().outbound_id("commands").unwrap();
-    let traces_id = child.channels().inbound_id("traces").unwrap();
+    let commands_id = child.channels().sender_id("commands").unwrap();
+    let traces_id = child.channels().receiver_id("traces").unwrap();
     assert_ne!(commands_id, traces_id);
 }
 
@@ -431,8 +431,8 @@ fn consuming_message_from_child_workflow() {
 
     let persisted = &workflow.data().persisted;
     let child = persisted.child_workflow(1).unwrap();
-    let child_commands_id = child.channels().outbound_id("commands").unwrap();
-    let child_traces_id = child.channels().inbound_id("traces").unwrap();
+    let child_commands_id = child.channels().sender_id("commands").unwrap();
+    let child_traces_id = child.channels().receiver_id("traces").unwrap();
 
     workflow
         .data_mut()
@@ -460,10 +460,10 @@ fn consuming_message_from_child_workflow() {
 }
 
 fn assert_child_inbound_message_receipt(workflow: &Workflow<'_>, receipt: &Receipt) {
-    let children = &workflow.data().persisted.child_workflows;
-    let child = children.values().next().unwrap();
-    let child_commands_id = child.channels().outbound_id("commands").unwrap();
-    let child_traces_id = child.channels().inbound_id("traces").unwrap();
+    let mut children = workflow.data().persisted.child_workflows();
+    let (_, child) = children.next().unwrap();
+    let child_commands_id = child.channels().sender_id("commands").unwrap();
+    let child_traces_id = child.channels().receiver_id("traces").unwrap();
 
     assert_matches!(
         &receipt.executions()[0],

--- a/crates/rt/src/data/tests/spawn.rs
+++ b/crates/rt/src/data/tests/spawn.rs
@@ -453,9 +453,9 @@ fn consuming_message_from_child_workflow() {
     assert_eq!(messages[&child_commands_id][0].as_ref(), b"command #1");
 
     let persisted = &workflow.data().persisted;
-    let child_traces = persisted.inbound_channel(child_traces_id).unwrap();
+    let child_traces = &persisted.channels.inbound[&child_traces_id];
     assert_eq!(child_traces.received_messages, 1);
-    let child_commands = persisted.outbound_channel(child_commands_id).unwrap();
+    let child_commands = &persisted.channels.outbound[&child_commands_id];
     assert_eq!(child_commands.flushed_messages, 1);
 }
 

--- a/crates/rt/src/data/tests/spawn.rs
+++ b/crates/rt/src/data/tests/spawn.rs
@@ -112,7 +112,7 @@ fn create_workflow_with_manager(services: Services<'_>) -> Workflow<'_> {
     workflow
 }
 
-fn spawn_child_workflow(mut ctx: StoreContextMut<'_, WorkflowData>) -> Result<Poll<()>, Trap> {
+fn spawn_child_workflow(mut ctx: StoreContextMut<'_, WorkflowData>) -> anyhow::Result<Poll<()>> {
     // Emulate getting interface.
     let (id_ptr, id_len) = WasmAllocator::new(ctx.as_context_mut()).copy_to_wasm(b"test:latest")?;
     let interface_res = SpawnFunctions::workflow_interface(ctx.as_context_mut(), id_ptr, id_len)?;
@@ -152,7 +152,7 @@ fn spawn_child_workflow(mut ctx: StoreContextMut<'_, WorkflowData>) -> Result<Po
 
 fn get_child_workflow_channel(
     mut ctx: StoreContextMut<'_, WorkflowData>,
-) -> Result<Poll<()>, Trap> {
+) -> anyhow::Result<Poll<()>> {
     let stub = Some(HostResource::WorkflowStub(0).into_ref());
     let workflow =
         SpawnFunctions::poll_workflow_init(ctx.as_context_mut(), stub, POLL_CX, ERROR_PTR)?;
@@ -180,7 +180,7 @@ fn get_child_workflow_channel(
 fn configure_handles(
     mut ctx: StoreContextMut<'_, WorkflowData>,
     handles: Option<ExternRef>,
-) -> Result<(), Trap> {
+) -> anyhow::Result<()> {
     let (name_ptr, name_len) =
         WasmAllocator::new(ctx.as_context_mut()).copy_to_wasm(b"commands")?;
     SpawnFunctions::set_channel_handle(
@@ -377,7 +377,7 @@ fn spawning_child_workflow_with_host_error() {
 
 fn consume_message_from_child(
     mut ctx: StoreContextMut<'_, WorkflowData>,
-) -> Result<Poll<()>, Trap> {
+) -> anyhow::Result<Poll<()>> {
     let traces = Some(WorkflowData::inbound_channel_ref(Some(1), "traces"));
     let commands = Some(WorkflowData::outbound_channel_ref(Some(1), "commands"));
 

--- a/crates/rt/src/driver/tests.rs
+++ b/crates/rt/src/driver/tests.rs
@@ -12,8 +12,8 @@ use super::*;
 use crate::{
     data::{WasmContextPtr, WorkflowData, WorkflowFunctions},
     manager::tests::{create_test_manager, create_test_workflow, is_consumption},
+    mock_scheduler::MockScheduler,
     module::{ExportsMock, MockPollFn},
-    test::MockScheduler,
     utils::WasmAllocator,
 };
 use tardigrade::{

--- a/crates/rt/src/driver/tests.rs
+++ b/crates/rt/src/driver/tests.rs
@@ -18,13 +18,13 @@ use crate::{
 };
 use tardigrade::{
     abi::AllocateBytes,
-    interface::{InboundChannel, OutboundChannel},
+    interface::{ReceiverName, SenderName},
 };
 
 const POLL_CX: WasmContextPtr = 123;
 
 fn poll_orders(mut ctx: StoreContextMut<'_, WorkflowData>) -> anyhow::Result<Poll<()>> {
-    let orders = Some(ctx.data().inbound_channel_ref(None, "orders"));
+    let orders = Some(ctx.data().receiver_ref(None, "orders"));
     let poll_result =
         WorkflowFunctions::poll_next_for_receiver(ctx.as_context_mut(), orders, POLL_CX)?;
     assert_eq!(poll_result, -1); // Pending
@@ -33,13 +33,13 @@ fn poll_orders(mut ctx: StoreContextMut<'_, WorkflowData>) -> anyhow::Result<Pol
 }
 
 fn handle_order(mut ctx: StoreContextMut<'_, WorkflowData>) -> anyhow::Result<Poll<()>> {
-    let orders = Some(ctx.data().inbound_channel_ref(None, "orders"));
+    let orders = Some(ctx.data().receiver_ref(None, "orders"));
     let poll_result =
         WorkflowFunctions::poll_next_for_receiver(ctx.as_context_mut(), orders, POLL_CX)?;
     assert_ne!(poll_result, -1);
     assert_ne!(poll_result, -2); // Ready(Some(_))
 
-    let events = Some(ctx.data_mut().outbound_channel_ref(None, "events"));
+    let events = Some(ctx.data_mut().sender_ref(None, "events"));
     let (event_ptr, event_len) =
         WasmAllocator::new(ctx.as_context_mut()).copy_to_wasm(b"event #1")?;
     WorkflowFunctions::start_send(ctx.as_context_mut(), events, event_ptr, event_len)?;
@@ -56,9 +56,9 @@ async fn completing_workflow_via_driver() {
     let mut workflow = create_test_workflow(&manager).await;
     let mut handle = workflow.handle();
     let mut driver = Driver::new();
-    let orders_sx = handle.remove(InboundChannel("orders")).unwrap();
+    let orders_sx = handle.remove(ReceiverName("orders")).unwrap();
     let mut orders_sx = orders_sx.into_sink(&mut driver);
-    let events_rx = handle.remove(OutboundChannel("events")).unwrap();
+    let events_rx = handle.remove(SenderName("events")).unwrap();
     let events_rx = events_rx.into_stream(&mut driver);
 
     let input_actions = async move {
@@ -74,12 +74,12 @@ async fn completing_workflow_via_driver() {
 
 async fn test_driver_with_multiple_messages(start_after_tick: bool) {
     let poll_orders_and_send_event: MockPollFn = |mut ctx| {
-        let orders = Some(ctx.data().inbound_channel_ref(None, "orders"));
+        let orders = Some(ctx.data().receiver_ref(None, "orders"));
         let poll_result =
             WorkflowFunctions::poll_next_for_receiver(ctx.as_context_mut(), orders, POLL_CX)?;
         assert_eq!(poll_result, -1); // Pending
 
-        let events = Some(ctx.data_mut().outbound_channel_ref(None, "events"));
+        let events = Some(ctx.data_mut().sender_ref(None, "events"));
         let (event_ptr, event_len) =
             WasmAllocator::new(ctx.as_context_mut()).copy_to_wasm(b"event #0")?;
         WorkflowFunctions::start_send(ctx.as_context_mut(), events, event_ptr, event_len)?;
@@ -92,8 +92,8 @@ async fn test_driver_with_multiple_messages(start_after_tick: bool) {
     let mut manager = create_test_manager(MockScheduler::default()).await;
     let mut workflow = create_test_workflow(&manager).await;
     let mut handle = workflow.handle();
-    let events_rx = handle.remove(OutboundChannel("events")).unwrap();
-    let orders_sx = handle.remove(InboundChannel("orders")).unwrap();
+    let events_rx = handle.remove(SenderName("events")).unwrap();
+    let orders_sx = handle.remove(ReceiverName("orders")).unwrap();
 
     if start_after_tick {
         manager.tick().await.unwrap().into_inner().unwrap();
@@ -146,10 +146,10 @@ async fn selecting_from_driver_and_other_future() {
     let mut handle = workflow.handle();
     let mut driver = Driver::new();
     let mut tick_results = driver.tick_results();
-    let orders_sx = handle.remove(InboundChannel("orders")).unwrap();
+    let orders_sx = handle.remove(ReceiverName("orders")).unwrap();
     let orders_id = orders_sx.channel_id();
     let mut orders_sx = orders_sx.into_sink(&mut driver);
-    let events_rx = handle.remove(OutboundChannel("events")).unwrap();
+    let events_rx = handle.remove(SenderName("events")).unwrap();
     let events_rx = events_rx.into_stream(&mut driver);
 
     let input_actions = orders_sx.send(b"order".to_vec()).map(Result::unwrap);
@@ -187,7 +187,7 @@ async fn selecting_from_driver_and_other_future() {
     // The `manager` can be used again.
     let mut workflow = manager.workflow(workflow_id).await.unwrap();
     let mut handle = workflow.handle();
-    handle[InboundChannel("orders")]
+    handle[ReceiverName("orders")]
         .send(b"order #2".to_vec())
         .await
         .unwrap();

--- a/crates/rt/src/driver/tests.rs
+++ b/crates/rt/src/driver/tests.rs
@@ -6,7 +6,7 @@ use futures::{
     SinkExt, TryStreamExt,
 };
 use mimicry::Answers;
-use wasmtime::{AsContextMut, StoreContextMut, Trap};
+use wasmtime::{AsContextMut, StoreContextMut};
 
 use super::*;
 use crate::{
@@ -24,7 +24,7 @@ use tardigrade::{
 
 const POLL_CX: WasmContextPtr = 123;
 
-fn poll_orders(mut ctx: StoreContextMut<'_, WorkflowData>) -> Result<Poll<()>, Trap> {
+fn poll_orders(mut ctx: StoreContextMut<'_, WorkflowData>) -> anyhow::Result<Poll<()>> {
     let orders = Some(WorkflowData::inbound_channel_ref(None, "orders"));
     let poll_result =
         WorkflowFunctions::poll_next_for_receiver(ctx.as_context_mut(), orders, POLL_CX)?;
@@ -33,7 +33,7 @@ fn poll_orders(mut ctx: StoreContextMut<'_, WorkflowData>) -> Result<Poll<()>, T
     Ok(Poll::Pending)
 }
 
-fn handle_order(mut ctx: StoreContextMut<'_, WorkflowData>) -> Result<Poll<()>, Trap> {
+fn handle_order(mut ctx: StoreContextMut<'_, WorkflowData>) -> anyhow::Result<Poll<()>> {
     let orders = Some(WorkflowData::inbound_channel_ref(None, "orders"));
     let poll_result =
         WorkflowFunctions::poll_next_for_receiver(ctx.as_context_mut(), orders, POLL_CX)?;

--- a/crates/rt/src/lib.rs
+++ b/crates/rt/src/lib.rs
@@ -24,6 +24,12 @@
 //!
 //! # Crate features
 //!
+//! ## `test`
+//!
+//! *(Off by default)*
+//!
+//! Provides the [`test`](crate::test) module with helpers for integration testing of workflows.
+//!
 //! ## `async-io`
 //!
 //! *(Off by default)*
@@ -122,6 +128,8 @@ pub mod manager;
 mod module;
 pub mod receipt;
 pub mod storage;
+#[cfg(feature = "test")]
+#[cfg_attr(docsrs, doc(cfg(feature = "test")))]
 pub mod test;
 mod utils;
 mod workflow;

--- a/crates/rt/src/lib.rs
+++ b/crates/rt/src/lib.rs
@@ -125,10 +125,12 @@ mod backends;
 mod data;
 pub mod driver;
 pub mod manager;
+#[cfg(any(test, feature = "test"))]
+mod mock_scheduler;
 mod module;
 pub mod receipt;
 pub mod storage;
-#[cfg(feature = "test")] // FIXME move `MockScheduler` so that lib tests work w/o feature=test
+#[cfg(feature = "test")]
 #[cfg_attr(docsrs, doc(cfg(feature = "test")))]
 pub mod test;
 mod utils;

--- a/crates/rt/src/lib.rs
+++ b/crates/rt/src/lib.rs
@@ -140,8 +140,7 @@ mod workflow;
 pub use crate::backends::AsyncIoScheduler;
 pub use crate::{
     data::{
-        ChannelMapping, ChildWorkflowState, InboundChannelState, OutboundChannelState, TaskState,
-        TimerState,
+        Channels, ChildWorkflow, InboundChannelState, OutboundChannelState, TaskState, TimerState,
     },
     module::{
         Clock, ExtendLinker, Schedule, TimerFuture, WorkflowEngine, WorkflowModule, WorkflowSpawner,

--- a/crates/rt/src/lib.rs
+++ b/crates/rt/src/lib.rs
@@ -128,7 +128,7 @@ pub mod manager;
 mod module;
 pub mod receipt;
 pub mod storage;
-#[cfg(feature = "test")]
+#[cfg(feature = "test")] // FIXME move `MockScheduler` so that lib tests work w/o feature=test
 #[cfg_attr(docsrs, doc(cfg(feature = "test")))]
 pub mod test;
 mod utils;
@@ -137,7 +137,10 @@ mod workflow;
 #[cfg(feature = "async-io")]
 pub use crate::backends::AsyncIoScheduler;
 pub use crate::{
-    data::{ChildWorkflowState, InboundChannelState, OutboundChannelState, TaskState, TimerState},
+    data::{
+        ChannelMapping, ChildWorkflowState, InboundChannelState, OutboundChannelState, TaskState,
+        TimerState,
+    },
     module::{
         Clock, ExtendLinker, Schedule, TimerFuture, WorkflowEngine, WorkflowModule, WorkflowSpawner,
     },

--- a/crates/rt/src/lib.rs
+++ b/crates/rt/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! The runtime provides a [`WorkflowManager`] in which workflows defined in a WASM module
 //! can be executed and [persisted](PersistedWorkflow) / restored. Interaction with a workflow
-//! (e.g., submitting messages to inbound channels or taking messages from outbound channels)
+//! (e.g., submitting messages to channel receivers or taking messages from senders)
 //! can be performed using low-level, synchronous [`WorkflowHandle`], or by driving the manager
 //! with the [`Driver`].
 //!
@@ -139,9 +139,7 @@ mod workflow;
 #[cfg(feature = "async-io")]
 pub use crate::backends::AsyncIoScheduler;
 pub use crate::{
-    data::{
-        Channels, ChildWorkflow, InboundChannelState, OutboundChannelState, TaskState, TimerState,
-    },
+    data::{Channels, ChildWorkflow, ReceiverState, SenderState, TaskState, TimerState},
     module::{
         Clock, ExtendLinker, Schedule, TimerFuture, WorkflowEngine, WorkflowModule, WorkflowSpawner,
     },

--- a/crates/rt/src/manager/handle.rs
+++ b/crates/rt/src/manager/handle.rs
@@ -115,7 +115,7 @@ impl<'a, M: AsManager> WorkflowHandle<'a, (), M> {
     ) -> WorkflowHandle<'a, (), M> {
         let ids = WorkflowAndChannelIds {
             workflow_id: id,
-            channel_ids: state.persisted.channel_ids().clone(),
+            channel_ids: state.persisted.channel_mapping().to_ids(),
         };
         let host_receiver_channels =
             Self::find_host_receiver_channels(transaction, &ids.channel_ids).await;

--- a/crates/rt/src/manager/handle.rs
+++ b/crates/rt/src/manager/handle.rs
@@ -115,7 +115,7 @@ impl<'a, M: AsManager> WorkflowHandle<'a, (), M> {
     ) -> WorkflowHandle<'a, (), M> {
         let ids = WorkflowAndChannelIds {
             workflow_id: id,
-            channel_ids: state.persisted.channel_mapping().to_ids(),
+            channel_ids: state.persisted.channels().to_ids(),
         };
         let host_receiver_channels =
             Self::find_host_receiver_channels(transaction, &ids.channel_ids).await;

--- a/crates/rt/src/manager/handle.rs
+++ b/crates/rt/src/manager/handle.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 use tardigrade::{
     channel::{Receiver, SendError, Sender},
-    interface::{AccessError, AccessErrorKind, InboundChannel, Interface, OutboundChannel},
+    interface::{AccessError, AccessErrorKind, Interface, ReceiverName, SenderName},
     task::JoinError,
     workflow::{GetInterface, TakeHandle, UntypedHandle},
     ChannelId, Decode, Encode, Raw, WorkflowId,
@@ -44,8 +44,8 @@ impl error::Error for ConcurrencyError {}
 /// Handle to an active workflow in a [`WorkflowManager`].
 ///
 /// This type is used as a type param for the [`TakeHandle`] trait. The returned handles
-/// allow interacting with the workflow (e.g., [send messages](MessageSender) via inbound channels
-/// and [take messages](MessageReceiver) from outbound channels).
+/// allow interacting with the workflow (e.g., [send messages](MessageSender)
+/// and [take messages](MessageReceiver) via channels).
 ///
 /// See [`Driver`] for a more high-level alternative.
 ///
@@ -55,7 +55,7 @@ impl error::Error for ConcurrencyError {}
 /// # Examples
 ///
 /// ```
-/// use tardigrade::interface::{InboundChannel, OutboundChannel};
+/// use tardigrade::interface::{ReceiverName, SenderName};
 /// use tardigrade_rt::manager::WorkflowHandle;
 /// # use tardigrade_rt::manager::AsManager;
 ///
@@ -68,12 +68,12 @@ impl error::Error for ConcurrencyError {}
 /// // We can create a handle to manipulate the workflow.
 /// let mut handle = workflow.handle();
 ///
-/// // Let's send a message via an inbound channel.
+/// // Let's send a message via a channel.
 /// let message = b"hello".to_vec();
-/// handle[InboundChannel("commands")].send(message).await?;
+/// handle[ReceiverName("commands")].send(message).await?;
 ///
 /// // Let's then take outbound messages from a certain channel:
-/// let message = handle[OutboundChannel("events")]
+/// let message = handle[SenderName("events")]
 ///     .receive_message(0)
 ///     .await?;
 /// let message: Vec<u8> = message.decode()?;
@@ -134,8 +134,8 @@ impl<'a, M: AsManager> WorkflowHandle<'a, (), M> {
         transaction: &impl ReadChannels,
         channel_ids: &ChannelIds,
     ) -> HashSet<ChannelId> {
-        let outbound_channel_ids = channel_ids.outbound.values();
-        let channel_tasks = outbound_channel_ids.map(|&id| async move {
+        let sender_ids = channel_ids.senders.values();
+        let channel_tasks = sender_ids.map(|&id| async move {
             let channel = transaction.channel(id).await.unwrap();
             Some(id).filter(|_| channel.receiver_workflow_id.is_none())
         });
@@ -224,7 +224,7 @@ impl<W: TakeHandle<Self, Id = ()>, M: AsManager> WorkflowHandle<'_, W, M> {
     }
 }
 
-/// Handle for an [inbound workflow channel](Receiver) that allows sending messages
+/// Handle for an workflow channel [`Receiver`] that allows sending messages
 /// via the channel.
 #[derive(Debug)]
 pub struct MessageSender<'a, T, C, M> {
@@ -277,7 +277,7 @@ where
         env: &mut WorkflowHandle<'a, W, M>,
         id: &str,
     ) -> Result<Self::Handle, AccessError> {
-        if let Some(channel_id) = env.ids.channel_ids.inbound.get(id).copied() {
+        if let Some(channel_id) = env.ids.channel_ids.receivers.get(id).copied() {
             Ok(MessageSender {
                 manager: env.manager,
                 channel_id,
@@ -285,12 +285,12 @@ where
                 _item: PhantomData,
             })
         } else {
-            Err(AccessErrorKind::Unknown.with_location(InboundChannel(id)))
+            Err(AccessErrorKind::Unknown.with_location(ReceiverName(id)))
         }
     }
 }
 
-/// Handle for an [outbound workflow channel](Sender) that allows taking messages
+/// Handle for an workflow channel [`Sender`] that allows taking messages
 /// from the channel.
 #[derive(Debug)]
 pub struct MessageReceiver<'a, T, C, M> {
@@ -364,7 +364,7 @@ impl<T, C: Decode<T> + Default, M: AsManager> MessageReceiver<'_, T, C, M> {
     }
 }
 
-/// Message or end of stream received from an outbound workflow channel.
+/// Message or end of stream received from a workflow channel.
 #[derive(Debug)]
 pub struct ReceivedMessage<T, C> {
     index: usize,
@@ -401,7 +401,7 @@ where
         env: &mut WorkflowHandle<'a, W, M>,
         id: &str,
     ) -> Result<Self::Handle, AccessError> {
-        if let Some(channel_id) = env.ids.channel_ids.outbound.get(id).copied() {
+        if let Some(channel_id) = env.ids.channel_ids.senders.get(id).copied() {
             Ok(MessageReceiver {
                 manager: env.manager,
                 channel_id,
@@ -410,7 +410,7 @@ where
                 _item: PhantomData,
             })
         } else {
-            Err(AccessErrorKind::Unknown.with_location(OutboundChannel(id)))
+            Err(AccessErrorKind::Unknown.with_location(SenderName(id)))
         }
     }
 }

--- a/crates/rt/src/manager/handle.rs
+++ b/crates/rt/src/manager/handle.rs
@@ -115,7 +115,7 @@ impl<'a, M: AsManager> WorkflowHandle<'a, (), M> {
     ) -> WorkflowHandle<'a, (), M> {
         let ids = WorkflowAndChannelIds {
             workflow_id: id,
-            channel_ids: state.persisted.channel_ids(),
+            channel_ids: state.persisted.channel_ids().clone(),
         };
         let host_receiver_channels =
             Self::find_host_receiver_channels(transaction, &ids.channel_ids).await;

--- a/crates/rt/src/manager/new_workflows.rs
+++ b/crates/rt/src/manager/new_workflows.rs
@@ -47,8 +47,8 @@ impl ChannelIds {
     ) -> Self {
         futures::pin_mut!(new_channel_ids);
         Self {
-            inbound: Self::map_channels(channels.inbound, &mut new_channel_ids).await,
-            outbound: Self::map_channels(channels.outbound, &mut new_channel_ids).await,
+            receivers: Self::map_channels(channels.receivers, &mut new_channel_ids).await,
+            senders: Self::map_channels(channels.senders, &mut new_channel_ids).await,
         }
     }
 
@@ -169,19 +169,19 @@ impl<'a> NewWorkflows<'a> {
         let child_id = transaction.allocate_workflow_id().await;
 
         tracing::debug!(?channel_ids, "handling channels for new workflow");
-        for (name, &channel_id) in &channel_ids.inbound {
+        for (name, &channel_id) in &channel_ids.receivers {
             let state = ChannelRecord::new(executed_workflow_id, Some(child_id));
             let state = transaction.get_or_insert_channel(channel_id, state).await;
             if state.is_closed {
-                persisted.close_inbound_channel(channel_id);
+                persisted.close_receiver(channel_id);
             }
-            tracing::debug!(name, channel_id, ?state, "prepared inbound channel");
+            tracing::debug!(name, channel_id, ?state, "prepared channel receiver");
         }
-        for (name, &channel_id) in &channel_ids.outbound {
+        for (name, &channel_id) in &channel_ids.senders {
             let state = ChannelRecord::new(Some(child_id), executed_workflow_id);
             let state = transaction.get_or_insert_channel(channel_id, state).await;
             if state.is_closed {
-                persisted.close_outbound_channel(channel_id);
+                persisted.close_sender(channel_id);
             } else {
                 transaction
                     .manipulate_channel(channel_id, |channel| {
@@ -189,7 +189,7 @@ impl<'a> NewWorkflows<'a> {
                     })
                     .await;
             }
-            tracing::debug!(name, channel_id, ?state, "prepared outbound channel");
+            tracing::debug!(name, channel_id, ?state, "prepared channel sender");
         }
 
         let (module_id, name_in_module) =
@@ -259,8 +259,8 @@ impl<C: Clock, S> ManageInterfaces for WorkflowManager<C, S> {
 }
 
 impl<C: Clock, S> SpecifyWorkflowChannels for WorkflowManager<C, S> {
-    type Inbound = ChannelId;
-    type Outbound = ChannelId;
+    type Receiver = ChannelId;
+    type Sender = ChannelId;
 }
 
 #[async_trait]

--- a/crates/rt/src/manager/persistence.rs
+++ b/crates/rt/src/manager/persistence.rs
@@ -90,12 +90,12 @@ impl<'a, T: StorageTransaction> StorageHelper<'a, T> {
     ) {
         let completion_receiver = if workflow.result().is_ready() {
             // Close all channels linked to the workflow.
-            for (.., state) in workflow.inbound_channels() {
-                self.close_channel_side(state.id(), ChannelSide::Receiver)
+            for (channel_id, _) in workflow.inbound_channels() {
+                self.close_channel_side(channel_id, ChannelSide::Receiver)
                     .await;
             }
-            for (.., state) in workflow.outbound_channels() {
-                self.close_channel_side(state.id(), ChannelSide::WorkflowSender(id))
+            for (channel_id, _) in workflow.outbound_channels() {
+                self.close_channel_side(channel_id, ChannelSide::WorkflowSender(id))
                     .await;
             }
             parent_id

--- a/crates/rt/src/manager/persistence.rs
+++ b/crates/rt/src/manager/persistence.rs
@@ -181,9 +181,9 @@ impl Receipt {
                     ChannelEventKind::InboundChannelClosed => {
                         Some((ChannelKind::Inbound, *channel_id))
                     }
-                    ChannelEventKind::OutboundChannelClosed {
-                        remaining_alias_count: 0,
-                    } => Some((ChannelKind::Outbound, *channel_id)),
+                    ChannelEventKind::OutboundChannelClosed => {
+                        Some((ChannelKind::Outbound, *channel_id))
+                    }
                     _ => None,
                 };
             }

--- a/crates/rt/src/manager/persistence.rs
+++ b/crates/rt/src/manager/persistence.rs
@@ -176,13 +176,12 @@ impl<'a, T: StorageTransaction> StorageHelper<'a, T> {
 impl Receipt {
     fn closed_channel_ids(&self) -> impl Iterator<Item = (ChannelKind, ChannelId)> + '_ {
         self.events().filter_map(|event| {
-            if let Some(ChannelEvent { kind, .. }) = event.as_channel_event() {
+            if let Some(ChannelEvent { kind, channel_id }) = event.as_channel_event() {
                 return match kind {
-                    ChannelEventKind::InboundChannelClosed(channel_id) => {
+                    ChannelEventKind::InboundChannelClosed => {
                         Some((ChannelKind::Inbound, *channel_id))
                     }
                     ChannelEventKind::OutboundChannelClosed {
-                        channel_id,
                         remaining_alias_count: 0,
                     } => Some((ChannelKind::Outbound, *channel_id)),
                     _ => None,

--- a/crates/rt/src/manager/tests/spawn.rs
+++ b/crates/rt/src/manager/tests/spawn.rs
@@ -1,6 +1,7 @@
 //! Tests related to interaction among workflows.
 
 use futures::future;
+use mimicry::AnswersSender;
 use wasmtime::ExternRef;
 
 use super::*;
@@ -115,28 +116,19 @@ fn poll_child_traces(mut ctx: StoreContextMut<'_, WorkflowData>) -> Result<Poll<
 
 #[async_std::test]
 async fn spawning_child_workflow() {
-    let receive_child_trace: MockPollFn = |mut ctx| {
-        let child_traces = Some(WorkflowData::inbound_channel_ref(Some(CHILD_ID), "traces"));
-        let poll_result =
-            WorkflowFunctions::poll_next_for_receiver(ctx.as_context_mut(), child_traces, POLL_CX)?;
-        assert_ne!(poll_result, -1); // Poll::Ready(Some(_))
-
-        Ok(Poll::Pending)
-    };
-
-    let poll_fns = Answers::from_values([
-        spawn_child,
-        poll_child_traces,
-        (|_| Ok(Poll::Pending)) as MockPollFn,
-        receive_child_trace,
-    ]);
+    let (poll_fns, mut poll_fn_sx) = Answers::channel();
     let _guard = ExportsMock::prepare(poll_fns);
     let manager = create_test_manager(()).await;
     let mut workflow = create_test_workflow(&manager).await;
     let workflow_id = workflow.id();
-    tick_workflow(&manager, workflow_id).await.unwrap();
-    workflow.update().await.unwrap();
 
+    poll_fn_sx
+        .send(spawn_child)
+        .async_scope(tick_workflow(&manager, workflow_id))
+        .await
+        .unwrap();
+
+    workflow.update().await.unwrap();
     let persisted = workflow.persisted();
     let wakeup_causes: Vec<_> = persisted.pending_wakeup_causes().collect();
     assert_matches!(
@@ -149,7 +141,11 @@ async fn spawning_child_workflow() {
     assert_eq!(child_id, CHILD_ID);
     let traces_id = child_state.inbound_channel("traces").unwrap().id();
 
-    tick_workflow(&manager, workflow_id).await.unwrap();
+    poll_fn_sx
+        .send(poll_child_traces)
+        .async_scope(tick_workflow(&manager, workflow_id))
+        .await
+        .unwrap();
     workflow.update().await.unwrap();
     let persisted = workflow.persisted();
     let wakeup_causes: Vec<_> = persisted.pending_wakeup_causes().collect();
@@ -167,13 +163,30 @@ async fn spawning_child_workflow() {
     }
 
     // Emulate the child workflow putting a message to the `traces` channel.
-    tick_workflow(&manager, child_id).await.unwrap();
+    poll_fn_sx
+        .send(|_| Ok(Poll::Pending))
+        .async_scope(tick_workflow(&manager, child_id))
+        .await
+        .unwrap();
     manager
         .send_message(traces_id, b"trace".to_vec())
         .await
         .unwrap();
 
-    let receipt = feed_message(&manager, workflow_id, "traces").await.unwrap();
+    let receive_child_trace: MockPollFn = |mut ctx| {
+        let child_traces = Some(WorkflowData::inbound_channel_ref(Some(CHILD_ID), "traces"));
+        let poll_result =
+            WorkflowFunctions::poll_next_for_receiver(ctx.as_context_mut(), child_traces, POLL_CX)?;
+        assert_ne!(poll_result, -1); // Poll::Ready(Some(_))
+
+        Ok(Poll::Pending)
+    };
+    let receipt = poll_fn_sx
+        .send(receive_child_trace)
+        .async_scope(feed_message(&manager, workflow_id, "traces"))
+        .await
+        .unwrap();
+
     let events = extract_channel_events(&receipt, Some(child_id), "traces");
     assert_matches!(
         events.as_slice(),
@@ -203,6 +216,17 @@ async fn spawning_child_workflow() {
 
 #[async_std::test]
 async fn sending_message_to_child() {
+    let (poll_fns, mut poll_fn_sx) = Answers::channel();
+    let _guard = ExportsMock::prepare(poll_fns);
+    let manager = create_test_manager(()).await;
+    let workflow_id = create_test_workflow(&manager).await.id();
+
+    poll_fn_sx
+        .send(spawn_child)
+        .async_scope(tick_workflow(&manager, workflow_id))
+        .await
+        .unwrap();
+
     let send_message_to_child: MockPollFn = |mut ctx| {
         let child_orders = Some(WorkflowData::outbound_channel_ref(Some(CHILD_ID), "orders"));
         let poll_result = WorkflowFunctions::poll_ready_for_sender(
@@ -224,32 +248,11 @@ async fn sending_message_to_child() {
 
         Ok(Poll::Pending)
     };
-    let init_child: MockPollFn = |mut ctx| {
-        let orders = Some(WorkflowData::inbound_channel_ref(None, "orders"));
-        let poll_result =
-            WorkflowFunctions::poll_next_for_receiver(ctx.as_context_mut(), orders, POLL_CX)?;
-        assert_eq!(poll_result, -1); // Poll::Pending
-        Ok(Poll::Pending)
-    };
-    let poll_orders_in_child: MockPollFn = |mut ctx| {
-        let orders = Some(WorkflowData::inbound_channel_ref(None, "orders"));
-        let poll_result =
-            WorkflowFunctions::poll_next_for_receiver(ctx.as_context_mut(), orders, POLL_CX)?;
-        assert_ne!(poll_result, -1); // Poll::Ready(Some(_))
-        Ok(Poll::Pending)
-    };
-
-    let poll_fns = Answers::from_values([
-        spawn_child,
-        send_message_to_child,
-        init_child,
-        poll_orders_in_child,
-    ]);
-    let _guard = ExportsMock::prepare(poll_fns);
-    let manager = create_test_manager(()).await;
-    let workflow_id = create_test_workflow(&manager).await.id();
-    tick_workflow(&manager, workflow_id).await.unwrap(); // initializes workflow
-    tick_workflow(&manager, workflow_id).await.unwrap(); // notifies about child initialization
+    poll_fn_sx
+        .send(send_message_to_child)
+        .async_scope(tick_workflow(&manager, workflow_id))
+        .await
+        .unwrap();
 
     let child = manager.workflow(CHILD_ID).await.unwrap();
     let child_channel_ids = child.persisted().channel_ids();
@@ -261,8 +264,31 @@ async fn sending_message_to_child() {
         assert_eq!(child_orders[0], b"child_order");
     }
 
-    tick_workflow(&manager, CHILD_ID).await.unwrap();
-    feed_message(&manager, CHILD_ID, "orders").await.unwrap();
+    let init_child: MockPollFn = |mut ctx| {
+        let orders = Some(WorkflowData::inbound_channel_ref(None, "orders"));
+        let poll_result =
+            WorkflowFunctions::poll_next_for_receiver(ctx.as_context_mut(), orders, POLL_CX)?;
+        assert_eq!(poll_result, -1); // Poll::Pending
+        Ok(Poll::Pending)
+    };
+    poll_fn_sx
+        .send(init_child)
+        .async_scope(tick_workflow(&manager, CHILD_ID))
+        .await
+        .unwrap();
+
+    let poll_orders_in_child: MockPollFn = |mut ctx| {
+        let orders = Some(WorkflowData::inbound_channel_ref(None, "orders"));
+        let poll_result =
+            WorkflowFunctions::poll_next_for_receiver(ctx.as_context_mut(), orders, POLL_CX)?;
+        assert_ne!(poll_result, -1); // Poll::Ready(Some(_))
+        Ok(Poll::Pending)
+    };
+    poll_fn_sx
+        .send(poll_orders_in_child)
+        .async_scope(feed_message(&manager, CHILD_ID, "orders"))
+        .await
+        .unwrap();
 }
 
 fn test_child_channels_after_closure(
@@ -282,7 +308,19 @@ fn test_child_channels_after_closure(
 }
 
 async fn test_child_workflow_channel_management(complete_child: bool) {
-    let poll_child_completion: MockPollFn = |mut ctx| {
+    let (poll_fns, mut poll_fn_sx) = Answers::channel();
+    let _guard = ExportsMock::prepare(poll_fns);
+    let manager = create_test_manager(()).await;
+    let mut workflow = create_test_workflow(&manager).await;
+    let workflow_id = workflow.id();
+
+    poll_fn_sx
+        .send(spawn_child)
+        .async_scope(tick_workflow(&manager, workflow_id))
+        .await
+        .unwrap();
+
+    let poll_child_traces_and_completion: MockPollFn = |mut ctx| {
         let _ = poll_child_traces(ctx.as_context_mut())?;
         let child = Some(WorkflowData::child_ref(CHILD_ID));
         let poll_result =
@@ -291,6 +329,20 @@ async fn test_child_workflow_channel_management(complete_child: bool) {
 
         Ok(Poll::Pending)
     };
+    poll_fn_sx
+        .send(poll_child_traces_and_completion)
+        .async_scope(tick_workflow(&manager, workflow_id))
+        .await
+        .unwrap();
+
+    workflow.update().await.unwrap();
+    let mut children: Vec<_> = workflow.persisted().child_workflows().collect();
+    assert_eq!(children.len(), 1);
+    let (child_id, child_state) = children.pop().unwrap();
+    assert_eq!(child_id, CHILD_ID);
+    let orders_id = child_state.outbound_channel("orders").unwrap().id();
+    let traces_id = child_state.inbound_channel("traces").unwrap().id();
+
     let poll_child_workflow: MockPollFn = if complete_child {
         |_| Ok(Poll::Ready(()))
     } else {
@@ -303,6 +355,29 @@ async fn test_child_workflow_channel_management(complete_child: bool) {
             Ok(Poll::Pending)
         }
     };
+    poll_fn_sx
+        .send(poll_child_workflow)
+        .async_scope(tick_workflow(&manager, child_id))
+        .await
+        .unwrap();
+
+    let channel_info = manager.channel(orders_id).await.unwrap();
+    assert!(channel_info.is_closed);
+    let channel_info = manager.channel(traces_id).await.unwrap();
+    assert!(channel_info.is_closed);
+
+    let wakers = wakers_for_workflow(&manager, workflow_id).await;
+    assert_matches!(
+        wakers[0],
+        WorkflowWaker::OutboundChannelClosure(id) if id == orders_id
+    );
+    if complete_child {
+        assert_eq!(wakers.len(), 2);
+        assert_matches!(wakers[1], WorkflowWaker::ChildCompletion(CHILD_ID));
+    } else {
+        assert_eq!(wakers.len(), 1);
+    }
+
     let test_child_resources: MockPollFn = if complete_child {
         |mut ctx| {
             let _ = test_child_channels_after_closure(ctx.as_context_mut())?;
@@ -316,48 +391,12 @@ async fn test_child_workflow_channel_management(complete_child: bool) {
     } else {
         test_child_channels_after_closure
     };
+    let receipt = poll_fn_sx
+        .send(test_child_resources)
+        .async_scope(tick_workflow(&manager, workflow_id))
+        .await
+        .unwrap();
 
-    let poll_fns = Answers::from_values([
-        spawn_child,
-        poll_child_completion,
-        poll_child_workflow,
-        test_child_resources,
-    ]);
-    let _guard = ExportsMock::prepare(poll_fns);
-    let manager = create_test_manager(()).await;
-    let mut workflow = create_test_workflow(&manager).await;
-    let workflow_id = workflow.id();
-    tick_workflow(&manager, workflow_id).await.unwrap(); // initializes workflow
-    tick_workflow(&manager, workflow_id).await.unwrap(); // notifies about child initialization
-
-    workflow.update().await.unwrap();
-    let mut children: Vec<_> = workflow.persisted().child_workflows().collect();
-    assert_eq!(children.len(), 1);
-    let (child_id, child_state) = children.pop().unwrap();
-    assert_eq!(child_id, CHILD_ID);
-    let orders_id = child_state.outbound_channel("orders").unwrap().id();
-    let traces_id = child_state.inbound_channel("traces").unwrap().id();
-
-    tick_workflow(&manager, child_id).await.unwrap();
-    let channel_info = manager.channel(orders_id).await.unwrap();
-    assert!(channel_info.is_closed);
-    let channel_info = manager.channel(traces_id).await.unwrap();
-    assert!(channel_info.is_closed);
-
-    let wakers = wakers_for_workflow(&manager, workflow_id).await;
-
-    assert_matches!(
-        wakers[0],
-        WorkflowWaker::OutboundChannelClosure(id) if id == orders_id
-    );
-    if complete_child {
-        assert_eq!(wakers.len(), 2);
-        assert_matches!(wakers[1], WorkflowWaker::ChildCompletion(CHILD_ID));
-    } else {
-        assert_eq!(wakers.len(), 1);
-    }
-
-    let receipt = tick_workflow(&manager, workflow_id).await.unwrap();
     workflow.update().await.unwrap();
     let child_state = workflow.persisted().child_workflow(child_id).unwrap();
     if complete_child {
@@ -454,29 +493,31 @@ fn poll_child_completion_with_copied_channel(
     Ok(Poll::Pending)
 }
 
+async fn init_workflow_with_copied_child_channel(
+    manager: &LocalManager,
+    workflow_id: WorkflowId,
+    poll_fn_sx: &mut AnswersSender<MockPollFn>,
+) {
+    let spawn_child: MockPollFn = |ctx| spawn_child_with_copied_outbound_channel(ctx, false);
+    poll_fn_sx
+        .send_all([spawn_child, poll_child_completion_with_copied_channel])
+        .async_scope(async {
+            tick_workflow(manager, workflow_id).await.unwrap();
+            tick_workflow(manager, workflow_id).await.unwrap();
+        })
+        .await;
+}
+
 #[async_std::test]
 async fn spawning_child_with_copied_outbound_channel() {
-    let init: MockPollFn = |ctx| spawn_child_with_copied_outbound_channel(ctx, false);
-    let write_event_and_complete_child: MockPollFn = |mut ctx| {
-        let events = Some(WorkflowData::outbound_channel_ref(None, "events"));
-        let (message_ptr, message_len) =
-            WasmAllocator::new(ctx.as_context_mut()).copy_to_wasm(b"child_event")?;
-        WorkflowFunctions::start_send(ctx.as_context_mut(), events, message_ptr, message_len)?;
-        Ok(Poll::Ready(()))
-    };
-
-    let poll_fns = Answers::from_values([
-        init,
-        poll_child_completion_with_copied_channel,
-        write_event_and_complete_child,
-    ]);
+    let (poll_fns, mut poll_fn_sx) = Answers::channel();
     let _guard = ExportsMock::prepare(poll_fns);
     let manager = create_test_manager(()).await;
     let workflow = create_test_workflow(&manager).await;
     let workflow_id = workflow.id();
     let events_id = workflow.ids().channel_ids.outbound["events"];
-    tick_workflow(&manager, workflow_id).await.unwrap(); // initializes workflow
-    tick_workflow(&manager, workflow_id).await.unwrap(); // notifies about child initialization
+
+    init_workflow_with_copied_child_channel(&manager, workflow_id, &mut poll_fn_sx).await;
 
     let events_channel = manager.channel(events_id).await.unwrap();
     assert_eq!(
@@ -496,7 +537,19 @@ async fn spawning_child_with_copied_outbound_channel() {
         });
     assert_eq!(child_events_id, Some(events_id));
 
-    tick_workflow(&manager, CHILD_ID).await.unwrap();
+    let write_event_and_complete_child: MockPollFn = |mut ctx| {
+        let events = Some(WorkflowData::outbound_channel_ref(None, "events"));
+        let (message_ptr, message_len) =
+            WasmAllocator::new(ctx.as_context_mut()).copy_to_wasm(b"child_event")?;
+        WorkflowFunctions::start_send(ctx.as_context_mut(), events, message_ptr, message_len)?;
+        Ok(Poll::Ready(()))
+    };
+    poll_fn_sx
+        .send(write_event_and_complete_child)
+        .async_scope(tick_workflow(&manager, CHILD_ID))
+        .await
+        .unwrap();
+
     let events_channel = manager.channel(events_id).await.unwrap();
     assert_eq!(
         events_channel.sender_workflow_ids,
@@ -510,7 +563,23 @@ async fn spawning_child_with_copied_outbound_channel() {
 }
 
 async fn test_child_with_copied_closed_outbound_channel(close_before_spawn: bool) {
-    let init: MockPollFn = |ctx| spawn_child_with_copied_outbound_channel(ctx, false);
+    let (poll_fns, mut poll_fn_sx) = Answers::channel();
+    let _guard = ExportsMock::prepare(poll_fns);
+    let manager = create_test_manager(()).await;
+    let workflow = create_test_workflow(&manager).await;
+    let workflow_id = workflow.id();
+    let events_id = workflow.ids().channel_ids.outbound["events"];
+
+    if close_before_spawn {
+        manager.close_host_receiver(events_id).await;
+    }
+
+    init_workflow_with_copied_child_channel(&manager, workflow_id, &mut poll_fn_sx).await;
+
+    if !close_before_spawn {
+        manager.close_host_receiver(events_id).await;
+    }
+
     let test_writing_event_in_child: MockPollFn = |mut ctx| {
         let events = Some(WorkflowData::outbound_channel_ref(None, "events"));
         let (message_ptr, message_len) =
@@ -521,28 +590,11 @@ async fn test_child_with_copied_closed_outbound_channel(close_before_spawn: bool
 
         Ok(Poll::Pending)
     };
-
-    let poll_fns = Answers::from_values([
-        init,
-        poll_child_completion_with_copied_channel,
-        test_writing_event_in_child,
-    ]);
-    let _guard = ExportsMock::prepare(poll_fns);
-    let manager = create_test_manager(()).await;
-    let workflow = create_test_workflow(&manager).await;
-    let workflow_id = workflow.id();
-    let events_id = workflow.ids().channel_ids.outbound["events"];
-
-    if close_before_spawn {
-        manager.close_host_receiver(events_id).await;
-    }
-    tick_workflow(&manager, workflow_id).await.unwrap(); // initializes workflow
-    tick_workflow(&manager, workflow_id).await.unwrap(); // notifies about child initialization
-
-    if !close_before_spawn {
-        manager.close_host_receiver(events_id).await;
-    }
-    tick_workflow(&manager, CHILD_ID).await.unwrap();
+    poll_fn_sx
+        .send(test_writing_event_in_child)
+        .async_scope(tick_workflow(&manager, CHILD_ID))
+        .await
+        .unwrap();
 }
 
 #[async_std::test]
@@ -556,7 +608,32 @@ async fn spawning_child_with_copied_then_closed_outbound_channel() {
 }
 
 async fn test_child_with_aliased_outbound_channel(complete_child: bool) {
-    let init: MockPollFn = |ctx| spawn_child_with_copied_outbound_channel(ctx, true);
+    let (poll_fns, mut poll_fn_sx) = Answers::channel();
+    let _guard = ExportsMock::prepare(poll_fns);
+    let manager = create_test_manager(()).await;
+    let workflow = create_test_workflow(&manager).await;
+    let workflow_id = workflow.id();
+    let events_id = workflow.ids().channel_ids.outbound["events"];
+
+    let spawn_child: MockPollFn = |ctx| spawn_child_with_copied_outbound_channel(ctx, true);
+    poll_fn_sx
+        .send_all([spawn_child, poll_child_completion_with_copied_channel])
+        .async_scope(async {
+            tick_workflow(&manager, workflow_id).await.unwrap();
+            tick_workflow(&manager, workflow_id).await.unwrap();
+        })
+        .await;
+
+    let events_channel = manager.channel(events_id).await.unwrap();
+    assert_eq!(
+        events_channel.sender_workflow_ids,
+        HashSet::from_iter([workflow_id, CHILD_ID])
+    );
+    let child = manager.workflow(CHILD_ID).await.unwrap();
+    let child_channel_ids = &child.ids().channel_ids;
+    assert_eq!(child_channel_ids.outbound["events"], events_id);
+    assert_eq!(child_channel_ids.outbound["traces"], events_id);
+
     let write_event_and_drop_events: MockPollFn = |mut ctx| {
         let events = Some(WorkflowData::outbound_channel_ref(None, "events"));
         let (message_ptr, message_len) =
@@ -583,41 +660,12 @@ async fn test_child_with_aliased_outbound_channel(complete_child: bool) {
         assert_eq!(poll_result, -1); // Poll::Pending
         Ok(Poll::Pending)
     };
-    let complete_child_or_drop_traces: MockPollFn = if complete_child {
-        |_| Ok(Poll::Ready(()))
-    } else {
-        |ctx| {
-            let traces = Some(WorkflowData::outbound_channel_ref(None, "traces"));
-            WorkflowFunctions::drop_ref(ctx, traces)?;
-            Ok(Poll::Pending)
-        }
-    };
+    poll_fn_sx
+        .send(write_event_and_drop_events)
+        .async_scope(tick_workflow(&manager, CHILD_ID))
+        .await
+        .unwrap();
 
-    let poll_fns = Answers::from_values([
-        init,
-        poll_child_completion_with_copied_channel,
-        write_event_and_drop_events,
-        complete_child_or_drop_traces,
-    ]);
-    let _guard = ExportsMock::prepare(poll_fns);
-    let manager = create_test_manager(()).await;
-    let workflow = create_test_workflow(&manager).await;
-    let workflow_id = workflow.id();
-    let events_id = workflow.ids().channel_ids.outbound["events"];
-    tick_workflow(&manager, workflow_id).await.unwrap(); // initializes workflow
-    tick_workflow(&manager, workflow_id).await.unwrap(); // notifies about child initialization
-
-    let events_channel = manager.channel(events_id).await.unwrap();
-    assert_eq!(
-        events_channel.sender_workflow_ids,
-        HashSet::from_iter([workflow_id, CHILD_ID])
-    );
-    let child = manager.workflow(CHILD_ID).await.unwrap();
-    let child_channel_ids = &child.ids().channel_ids;
-    assert_eq!(child_channel_ids.outbound["events"], events_id);
-    assert_eq!(child_channel_ids.outbound["traces"], events_id);
-
-    tick_workflow(&manager, CHILD_ID).await.unwrap();
     let events_channel = manager.channel(events_id).await.unwrap();
     assert_eq!(
         events_channel.sender_workflow_ids,
@@ -628,7 +676,20 @@ async fn test_child_with_aliased_outbound_channel(complete_child: bool) {
     assert_eq!(outbound_messages, [b"child_event" as &[u8], b"child_trace"]);
     drop(transaction);
 
-    tick_workflow(&manager, CHILD_ID).await.unwrap();
+    let guard = if complete_child {
+        poll_fn_sx.send(|_| Ok(Poll::Ready(())))
+    } else {
+        poll_fn_sx.send(|ctx| {
+            let traces = Some(WorkflowData::outbound_channel_ref(None, "traces"));
+            WorkflowFunctions::drop_ref(ctx, traces)?;
+            Ok(Poll::Pending)
+        })
+    };
+    guard
+        .async_scope(tick_workflow(&manager, CHILD_ID))
+        .await
+        .unwrap();
+
     let events_channel = manager.channel(events_id).await.unwrap();
     assert_eq!(
         events_channel.sender_workflow_ids,
@@ -657,6 +718,28 @@ fn poll_child_completion(mut ctx: StoreContextMut<'_, WorkflowData>) -> Result<P
 
 #[async_std::test]
 async fn completing_child_with_error() {
+    let (poll_fns, mut poll_fn_sx) = Answers::channel();
+    let _guard = ExportsMock::prepare(poll_fns);
+    let manager = create_test_manager(()).await;
+    let workflow_id = create_test_workflow(&manager).await.id();
+
+    poll_fn_sx
+        .send_all([spawn_child, poll_child_completion, complete_task_with_error])
+        .async_scope(async {
+            tick_workflow(&manager, workflow_id).await.unwrap();
+            tick_workflow(&manager, workflow_id).await.unwrap();
+            tick_workflow(&manager, CHILD_ID).await.unwrap();
+        })
+        .await;
+
+    let child = manager.any_workflow(CHILD_ID).await.unwrap();
+    assert!(child.is_completed());
+    let child = child.unwrap_completed();
+    assert_matches!(
+        child.result(),
+        Err(JoinError::Err(err)) if err.cause().to_string() == "error message"
+    );
+
     let check_child_completion: MockPollFn = |mut ctx| {
         let child = Some(WorkflowData::child_ref(CHILD_ID));
         let poll_result =
@@ -672,29 +755,12 @@ async fn completing_child_with_error() {
 
         Ok(Poll::Pending)
     };
+    let receipt = poll_fn_sx
+        .send(check_child_completion)
+        .async_scope(tick_workflow(&manager, workflow_id))
+        .await
+        .unwrap();
 
-    let poll_fns = Answers::from_values([
-        spawn_child,
-        poll_child_completion,
-        complete_task_with_error,
-        check_child_completion,
-    ]);
-    let _guard = ExportsMock::prepare(poll_fns);
-    let manager = create_test_manager(()).await;
-    let workflow_id = create_test_workflow(&manager).await.id();
-    tick_workflow(&manager, workflow_id).await.unwrap(); // initializes workflow
-    tick_workflow(&manager, workflow_id).await.unwrap(); // notifies about child initialization
-    tick_workflow(&manager, CHILD_ID).await.unwrap();
-
-    let child = manager.any_workflow(CHILD_ID).await.unwrap();
-    assert!(child.is_completed());
-    let child = child.unwrap_completed();
-    assert_matches!(
-        child.result(),
-        Err(JoinError::Err(err)) if err.cause().to_string() == "error message"
-    );
-
-    let receipt = tick_workflow(&manager, workflow_id).await.unwrap();
     let is_child_polled = receipt.events().any(|event| {
         event.as_resource_event().map_or(false, |event| {
             matches!(event.resource_id, ResourceId::Workflow(CHILD_ID))
@@ -745,26 +811,30 @@ fn check_aborted_child_completion(
 
 #[async_std::test]
 async fn completing_child_with_panic() {
-    let poll_fns = Answers::from_values([
-        spawn_child,
-        poll_child_completion,
-        complete_task_with_panic,
-        check_aborted_child_completion,
-    ]);
+    let (poll_fns, mut poll_fn_sx) = Answers::channel();
     let _guard = ExportsMock::prepare(poll_fns);
     let manager = create_test_manager(()).await;
     let workflow_id = create_test_workflow(&manager).await.id();
 
-    let tick_result = manager.tick().await.unwrap();
+    let tick_result = poll_fn_sx
+        .send(spawn_child)
+        .async_scope(manager.tick())
+        .await
+        .unwrap();
     assert_eq!(tick_result.workflow_id(), workflow_id);
     tick_result.into_inner().unwrap();
     let child = manager.workflow(CHILD_ID).await.unwrap();
     let child_events_id = child.ids().channel_ids.outbound["events"];
 
-    // Both workflow are ready to be polled at this point; control which one is polled first.
-    tick_workflow(&manager, workflow_id).await.unwrap();
-
-    let tick_result = manager.tick().await.unwrap();
+    let tick_result = poll_fn_sx
+        .send_all([poll_child_completion, complete_task_with_panic])
+        .async_scope(async {
+            // Both workflows are ready to be polled at this point;
+            // control which one is polled first.
+            tick_workflow(&manager, workflow_id).await.unwrap();
+            manager.tick().await.unwrap()
+        })
+        .await;
     assert_eq!(tick_result.workflow_id(), CHILD_ID);
     let err_handle = tick_result.into_inner().unwrap_err();
     assert_eq!(
@@ -786,11 +856,12 @@ async fn completing_child_with_panic() {
     let child = child.unwrap_completed();
     assert_matches!(child.result(), Err(JoinError::Aborted));
 
-    assert_child_abort(&manager, workflow_id, child_events_id).await;
+    assert_child_abort(&manager, &mut poll_fn_sx, workflow_id, child_events_id).await;
 }
 
 async fn assert_child_abort(
     manager: &WorkflowManager<(), LocalStorage>,
+    poll_fn_sx: &mut AnswersSender<MockPollFn>,
     workflow_id: WorkflowId,
     child_events_id: ChannelId,
 ) {
@@ -799,7 +870,11 @@ async fn assert_child_abort(
     assert_eq!(child_events.received_messages, 0);
     assert!(child_events.is_closed);
 
-    let receipt = tick_workflow(manager, workflow_id).await.unwrap();
+    let receipt = poll_fn_sx
+        .send(check_aborted_child_completion)
+        .async_scope(tick_workflow(manager, workflow_id))
+        .await
+        .unwrap();
     let is_child_polled = receipt.events().any(|event| {
         event.as_resource_event().map_or(false, |event| {
             matches!(event.resource_id, ResourceId::Workflow(CHILD_ID))
@@ -809,37 +884,40 @@ async fn assert_child_abort(
     assert!(is_child_polled, "{receipt:?}");
 }
 
-async fn test_aborting_child(initialize_child: bool) {
-    let poll_fns: Vec<MockPollFn> = if initialize_child {
-        vec![
-            spawn_child,
-            poll_child_completion,
-            |_| Ok(Poll::Pending),
-            check_aborted_child_completion,
-        ]
-    } else {
-        vec![
-            spawn_child,
-            poll_child_completion,
-            check_aborted_child_completion,
-        ]
-    };
+async fn init_workflow_with_child(
+    manager: &LocalManager,
+    workflow_id: WorkflowId,
+    poll_fn_sx: &mut AnswersSender<MockPollFn>,
+) {
+    poll_fn_sx
+        .send_all([spawn_child, poll_child_completion])
+        .async_scope(async {
+            tick_workflow(manager, workflow_id).await.unwrap();
+            tick_workflow(manager, workflow_id).await.unwrap();
+        })
+        .await;
+}
 
-    let poll_fns = Answers::from_values(poll_fns);
+async fn test_aborting_child(initialize_child: bool) {
+    let (poll_fns, mut poll_fn_sx) = Answers::channel();
     let _guard = ExportsMock::prepare(poll_fns);
     let manager = create_test_manager(()).await;
     let workflow_id = create_test_workflow(&manager).await.id();
-    tick_workflow(&manager, workflow_id).await.unwrap();
-    tick_workflow(&manager, workflow_id).await.unwrap();
+
+    init_workflow_with_child(&manager, workflow_id, &mut poll_fn_sx).await;
 
     let child = manager.workflow(CHILD_ID).await.unwrap();
     let child_events_id = child.ids().channel_ids.outbound["events"];
     if initialize_child {
-        tick_workflow(&manager, CHILD_ID).await.unwrap();
+        poll_fn_sx
+            .send(|_| Ok(Poll::Pending))
+            .async_scope(tick_workflow(&manager, CHILD_ID))
+            .await
+            .unwrap();
     }
     manager.abort_workflow(CHILD_ID).await.unwrap();
 
-    assert_child_abort(&manager, workflow_id, child_events_id).await;
+    assert_child_abort(&manager, &mut poll_fn_sx, workflow_id, child_events_id).await;
 }
 
 #[async_std::test]
@@ -854,6 +932,22 @@ async fn aborting_child_after_initialization() {
 
 #[async_std::test]
 async fn aborting_parent() {
+    let (poll_fns, mut poll_fn_sx) = Answers::channel();
+    let _guard = ExportsMock::prepare(poll_fns);
+    let manager = create_test_manager(()).await;
+    let workflow_id = create_test_workflow(&manager).await.id();
+
+    init_workflow_with_child(&manager, workflow_id, &mut poll_fn_sx).await;
+
+    let child = manager.workflow(CHILD_ID).await.unwrap();
+    let child_events_id = child.ids().channel_ids.outbound["events"];
+    let child_orders_id = child.ids().channel_ids.inbound["orders"];
+    manager.abort_workflow(workflow_id).await.unwrap();
+    let child_events = manager.channel(child_events_id).await.unwrap();
+    assert!(child_events.is_closed);
+    let child_orders = manager.channel(child_orders_id).await.unwrap();
+    assert!(child_orders.is_closed);
+
     let check_child_channels: MockPollFn = |mut ctx| {
         let orders = Some(WorkflowData::inbound_channel_ref(None, "orders"));
         let poll_result =
@@ -869,23 +963,11 @@ async fn aborting_parent() {
 
         Ok(Poll::Ready(()))
     };
+    poll_fn_sx
+        .send(check_child_channels)
+        .async_scope(tick_workflow(&manager, CHILD_ID))
+        .await
+        .unwrap();
 
-    let poll_fns = Answers::from_values([spawn_child, poll_child_completion, check_child_channels]);
-    let _guard = ExportsMock::prepare(poll_fns);
-    let manager = create_test_manager(()).await;
-    let workflow_id = create_test_workflow(&manager).await.id();
-
-    tick_workflow(&manager, workflow_id).await.unwrap();
-    tick_workflow(&manager, workflow_id).await.unwrap();
-    let child = manager.workflow(CHILD_ID).await.unwrap();
-    let child_events_id = child.ids().channel_ids.outbound["events"];
-    let child_orders_id = child.ids().channel_ids.inbound["orders"];
-    manager.abort_workflow(workflow_id).await.unwrap();
-    let child_events = manager.channel(child_events_id).await.unwrap();
-    assert!(child_events.is_closed);
-    let child_orders = manager.channel(child_orders_id).await.unwrap();
-    assert!(child_orders.is_closed);
-
-    tick_workflow(&manager, CHILD_ID).await.unwrap();
     assert!(manager.workflow(CHILD_ID).await.is_none());
 }

--- a/crates/rt/src/manager/tick.rs
+++ b/crates/rt/src/manager/tick.rs
@@ -153,12 +153,12 @@ impl<'a> WorkflowSeed<'a> {
         transaction: &T,
     ) -> Option<PendingChannel> {
         let channels = self.persisted.inbound_channels();
-        let pending_channels = channels.filter_map(|(_, state)| {
+        let pending_channels = channels.filter_map(|(id, state)| {
             if state.is_closed() {
                 None
             } else {
                 Some(PendingChannel {
-                    channel_id: state.id(),
+                    channel_id: id,
                     message_idx: state.received_message_count(),
                     waits_for_message: state.waits_for_message(),
                 })

--- a/crates/rt/src/mock_scheduler.rs
+++ b/crates/rt/src/mock_scheduler.rs
@@ -22,7 +22,7 @@ use tardigrade::test::MockScheduler as SchedulerBase;
 /// ```
 /// # use async_std::task;
 /// # use futures::TryStreamExt;
-/// # use tardigrade::{interface::OutboundChannel, spawn::ManageWorkflowsExt};
+/// # use tardigrade::{interface::SenderName, spawn::ManageWorkflowsExt};
 /// # use tardigrade_rt::{
 /// #     driver::Driver, manager::{WorkflowHandle, WorkflowManager}, storage::LocalStorage,
 /// #     test::MockScheduler, WorkflowModule,
@@ -45,7 +45,7 @@ use tardigrade::test::MockScheduler as SchedulerBase;
 /// // Spin up the driver to execute the `workflow`.
 /// let mut driver = Driver::new();
 /// let mut handle = workflow.handle();
-/// let mut events_rx = handle.remove(OutboundChannel("events"))
+/// let mut events_rx = handle.remove(SenderName("events"))
 ///     .unwrap()
 ///     .into_stream(&mut driver);
 /// task::spawn(async move { driver.drive(&mut manager).await });

--- a/crates/rt/src/mock_scheduler.rs
+++ b/crates/rt/src/mock_scheduler.rs
@@ -1,0 +1,134 @@
+//! `MockScheduler`.
+
+use chrono::{DateTime, Utc};
+use futures::{channel::mpsc, Stream};
+
+use std::{
+    ops,
+    sync::{Arc, Mutex},
+};
+
+use crate::{Clock, Schedule, TimerFuture};
+use tardigrade::test::MockScheduler as SchedulerBase;
+
+/// Mock [wall clock](Clock) and [scheduler](Schedule).
+///
+/// # Examples
+///
+/// A primary use case is to use the scheduler with a [`Driver`] for integration testing:
+///
+/// [`Driver`]: crate::driver::Driver
+///
+/// ```
+/// # use async_std::task;
+/// # use futures::TryStreamExt;
+/// # use tardigrade::{interface::OutboundChannel, spawn::ManageWorkflowsExt};
+/// # use tardigrade_rt::{
+/// #     driver::Driver, manager::{WorkflowHandle, WorkflowManager}, storage::LocalStorage,
+/// #     test::MockScheduler, WorkflowModule,
+/// # };
+/// # async fn test_wrapper(module: WorkflowModule) -> anyhow::Result<()> {
+/// let scheduler = MockScheduler::default();
+/// // Set the mocked wall clock for the workflow manager.
+/// let storage = LocalStorage::default();
+/// let mut manager = WorkflowManager::builder(storage)
+///     .with_clock(scheduler.clone())
+///     .build()
+///     .await?;
+/// let inputs: Vec<u8> = // ...
+/// #   vec![];
+/// let mut workflow = manager
+///     .new_workflow::<()>("test::Workflow", inputs)?
+///     .build()
+///     .await?;
+///
+/// // Spin up the driver to execute the `workflow`.
+/// let mut driver = Driver::new();
+/// let mut handle = workflow.handle();
+/// let mut events_rx = handle.remove(OutboundChannel("events"))
+///     .unwrap()
+///     .into_stream(&mut driver);
+/// task::spawn(async move { driver.drive(&mut manager).await });
+///
+/// // Advance mocked wall clock.
+/// let now = scheduler.now();
+/// scheduler.set_now(now + chrono::Duration::seconds(1));
+/// // This can lead to the workflow progressing, e.g., by emitting messages
+/// let message: Option<Vec<u8>> = events_rx.try_next().await?;
+/// // Assert on `message`...
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone)]
+pub struct MockScheduler {
+    inner: Arc<Mutex<SchedulerBase>>,
+    new_expirations_sx: mpsc::UnboundedSender<DateTime<Utc>>,
+}
+
+impl Default for MockScheduler {
+    fn default() -> Self {
+        Self {
+            inner: Arc::default(),
+            new_expirations_sx: mpsc::unbounded().0,
+        }
+    }
+}
+
+#[cfg_attr(test, allow(dead_code))] // some pub methods are not used in tests
+impl MockScheduler {
+    /// Creates a mock scheduler together with a stream that notifies the consumer
+    /// about new timer expirations.
+    pub fn with_expirations() -> (Self, impl Stream<Item = DateTime<Utc>> + Unpin) {
+        let (new_expirations_sx, rx) = mpsc::unbounded();
+        let this = Self {
+            inner: Arc::default(),
+            new_expirations_sx,
+        };
+        (this, rx)
+    }
+
+    fn inner(&self) -> impl ops::DerefMut<Target = SchedulerBase> + '_ {
+        self.inner.lock().unwrap()
+    }
+
+    /// Returns the expiration for the nearest timer, or `None` if there are no active timers.
+    pub fn next_timer_expiration(&self) -> Option<DateTime<Utc>> {
+        self.inner().next_timer_expiration()
+    }
+
+    /// Returns the current timestamp.
+    pub fn now(&self) -> DateTime<Utc> {
+        self.inner().now()
+    }
+
+    /// Sets the current timestamp for the scheduler.
+    pub fn set_now(&self, now: DateTime<Utc>) {
+        self.inner().set_now(now);
+    }
+}
+
+impl Clock for MockScheduler {
+    fn now(&self) -> DateTime<Utc> {
+        self.now()
+    }
+}
+
+impl Schedule for MockScheduler {
+    fn create_timer(&self, expires_at: DateTime<Utc>) -> TimerFuture {
+        use futures::{future, FutureExt};
+
+        let mut guard = self.inner();
+        let now = guard.now();
+        if now >= expires_at {
+            Box::pin(future::ready(now))
+        } else {
+            self.new_expirations_sx.unbounded_send(expires_at).ok();
+            Box::pin(guard.insert_timer(expires_at).then(|res| match res {
+                Ok(timestamp) => future::ready(timestamp).left_future(),
+                Err(_) => future::pending().right_future(),
+                // ^ An error can occur when the mock scheduler is dropped, usually at the end
+                // of a test. In this case the timer never expires.
+            }))
+        }
+    }
+}

--- a/crates/rt/src/module/imports.rs
+++ b/crates/rt/src/module/imports.rs
@@ -234,7 +234,6 @@ mod tests {
     use super::*;
     use crate::{
         module::{LowLevelExtendLinker, Services},
-        test::MockScheduler,
         workflow::ChannelIds,
     };
     use tardigrade::interface::Interface;
@@ -243,7 +242,7 @@ mod tests {
     fn import_checks_are_consistent() {
         let interface = Interface::default();
         let services = Services {
-            clock: &MockScheduler::default(),
+            clock: &(),
             workflows: None,
             tracer: None,
         };

--- a/crates/rt/src/module/imports.rs
+++ b/crates/rt/src/module/imports.rs
@@ -247,7 +247,7 @@ mod tests {
             workflows: None,
             tracer: None,
         };
-        let state = WorkflowData::new(&interface, &ChannelIds::default(), services);
+        let state = WorkflowData::new(&interface, ChannelIds::default(), services);
         let engine = Engine::default();
         let mut store = Store::new(&engine, state);
         let mut linker = Linker::new(&engine);

--- a/crates/rt/src/module/tests.rs
+++ b/crates/rt/src/module/tests.rs
@@ -53,7 +53,7 @@ impl ExportsMock {
             map.insert("TestWorkflow".to_owned(), Interface::from_bytes(INTERFACE));
             Ok(map)
         } else {
-            this.call_real(|| WorkflowModule::interfaces_from_wasm(bytes))
+            this.call_real().scope(|| WorkflowModule::interfaces_from_wasm(bytes))
         }
     }
 

--- a/crates/rt/src/module/tests.rs
+++ b/crates/rt/src/module/tests.rs
@@ -1,7 +1,7 @@
 //! Mocks for `WorkflowModule`s.
 
 use mimicry::{Answers, CallReal, Mock, MockGuard, Mut};
-use wasmtime::{StoreContextMut, Trap};
+use wasmtime::StoreContextMut;
 
 use std::{
     collections::{HashMap, HashSet},
@@ -18,7 +18,7 @@ const INTERFACE: &[u8] = br#"{
     "out": { "events": {}, "traces": { "capacity": null } }
 }"#;
 
-pub(crate) type MockPollFn = fn(StoreContextMut<'_, WorkflowData>) -> Result<Poll<()>, Trap>;
+pub(crate) type MockPollFn = fn(StoreContextMut<'_, WorkflowData>) -> anyhow::Result<Poll<()>>;
 
 #[derive(Default, Mock)]
 #[mock(mut)]
@@ -53,7 +53,8 @@ impl ExportsMock {
             map.insert("TestWorkflow".to_owned(), Interface::from_bytes(INTERFACE));
             Ok(map)
         } else {
-            this.call_real().scope(|| WorkflowModule::interfaces_from_wasm(bytes))
+            this.call_real()
+                .scope(|| WorkflowModule::interfaces_from_wasm(bytes))
         }
     }
 

--- a/crates/rt/src/receipt.rs
+++ b/crates/rt/src/receipt.rs
@@ -26,29 +26,20 @@ use tardigrade::{
 pub enum WakeUpCause {
     /// Woken up by an inbound message.
     InboundMessage {
-        /// ID of the remote workflow that the channel is attached to, or `None` if the channel
-        /// is local.
-        workflow_id: Option<WorkflowId>,
-        /// Name of the inbound channel that has received a message.
-        channel_name: String,
+        /// ID of the channel.
+        channel_id: ChannelId,
         /// 0-based message index.
         message_index: usize,
     },
     /// Woken up by an inbound channel getting closed.
     ChannelClosed {
-        /// ID of the remote workflow that the channel is attached to, or `None` if the channel
-        /// is local.
-        workflow_id: Option<WorkflowId>,
-        /// Name of the inbound channel that was closed.
-        channel_name: String,
+        /// ID of the channel.
+        channel_id: ChannelId,
     },
     /// Woken up by flushing an outbound channel.
     Flush {
-        /// ID of the remote workflow that the channel is attached to, or `None` if the channel
-        /// is local.
-        workflow_id: Option<WorkflowId>,
-        /// Name of the outbound channel that was flushed.
-        channel_name: String,
+        /// ID of the channel.
+        channel_id: ChannelId,
         /// Indexes of flushed messages.
         message_indexes: Range<usize>,
     },
@@ -196,7 +187,7 @@ pub enum ChannelEventKind {
         result: Poll<Option<usize>>,
     },
     /// Inbound channel closed by the workflow logic.
-    InboundChannelClosed(ChannelId),
+    InboundChannelClosed,
 
     /// Outbound channel was polled for readiness.
     OutboundChannelReady {
@@ -217,8 +208,6 @@ pub enum ChannelEventKind {
     },
     /// Outbound channel closed by the workflow logic.
     OutboundChannelClosed {
-        /// Channel ID.
-        channel_id: ChannelId,
         /// Number of remaining outbound workflow channels with the same ID.
         remaining_alias_count: usize,
     },
@@ -230,11 +219,8 @@ pub enum ChannelEventKind {
 pub struct ChannelEvent {
     /// Event kind.
     pub kind: ChannelEventKind,
-    /// Name of the channel.
-    pub channel_name: String,
-    /// ID of the remote workflow that the channel is attached to, or `None` if the channel
-    /// is local.
-    pub workflow_id: Option<WorkflowId>,
+    /// ID of the channel.
+    pub channel_id: ChannelId,
 }
 
 /// Event included into a [`Receipt`].

--- a/crates/rt/src/receipt.rs
+++ b/crates/rt/src/receipt.rs
@@ -207,10 +207,7 @@ pub enum ChannelEventKind {
         result: Poll<Result<(), SendError>>,
     },
     /// Outbound channel closed by the workflow logic.
-    OutboundChannelClosed {
-        /// Number of remaining outbound workflow channels with the same ID.
-        remaining_alias_count: usize,
-    },
+    OutboundChannelClosed,
 }
 
 /// Event related to an inbound or outbound workflow channel.

--- a/crates/rt/src/receipt.rs
+++ b/crates/rt/src/receipt.rs
@@ -31,12 +31,12 @@ pub enum WakeUpCause {
         /// 0-based message index.
         message_index: usize,
     },
-    /// Woken up by an inbound channel getting closed.
+    /// Woken up by a channel getting closed.
     ChannelClosed {
         /// ID of the channel.
         channel_id: ChannelId,
     },
-    /// Woken up by flushing an outbound channel.
+    /// Woken up by flushing a channel.
     Flush {
         /// ID of the channel.
         channel_id: ChannelId,
@@ -180,37 +180,37 @@ pub struct ResourceEvent {
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum ChannelEventKind {
-    /// Inbound channel was polled for messages.
-    InboundChannelPolled {
+    /// Channel receiver was polled for messages.
+    ReceiverPolled {
         /// Result of a poll, with the message replaced with its byte length.
         #[serde(with = "serde_poll")]
         result: Poll<Option<usize>>,
     },
-    /// Inbound channel closed by the workflow logic.
-    InboundChannelClosed,
+    /// Channel receiver closed by the workflow logic.
+    ReceiverClosed,
 
-    /// Outbound channel was polled for readiness.
-    OutboundChannelReady {
+    /// Channel sender was polled for readiness.
+    SenderReady {
         /// Result of a poll.
         #[serde(with = "serde_poll_res")]
         result: Poll<Result<(), SendError>>,
     },
-    /// Message was sent via an outbound channel.
+    /// Message was sent via a channel sender.
     OutboundMessageSent {
         /// Byte length of the sent message.
         message_len: usize,
     },
-    /// Outbound channel was polled for flush.
-    OutboundChannelFlushed {
+    /// Channel sender was polled for flush.
+    SenderFlushed {
         /// Result of a poll.
         #[serde(with = "serde_poll_res")]
         result: Poll<Result<(), SendError>>,
     },
-    /// Outbound channel closed by the workflow logic.
-    OutboundChannelClosed,
+    /// Channel sender closed by the workflow logic.
+    SenderClosed,
 }
 
-/// Event related to an inbound or outbound workflow channel.
+/// Event related to a workflow channel receiver or sender.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct ChannelEvent {
@@ -227,7 +227,7 @@ pub struct ChannelEvent {
 pub enum Event {
     /// Event related to a host-managed resource (a task or a timer).
     Resource(ResourceEvent),
-    /// Event related to an inbound or outbound channel.
+    /// Event related to a channel sender / receiver.
     Channel(ChannelEvent),
 }
 

--- a/crates/rt/src/storage/local.rs
+++ b/crates/rt/src/storage/local.rs
@@ -449,7 +449,7 @@ impl WriteWorkflows for LocalTransaction<'_> {
         let mut all_channels = workflows.flat_map(|(record, persisted)| {
             persisted
                 .inbound_channels()
-                .map(move |(_, _, state)| (record, state))
+                .map(move |(_, state)| (record, state))
         });
 
         all_channels.find_map(|(record, state)| {
@@ -527,7 +527,7 @@ impl StorageTransaction for LocalTransaction<'_> {
                         WorkflowState::Active(state) => &state.persisted,
                         WorkflowState::Completed(_) | WorkflowState::Errored(_) => continue,
                     };
-                    let (.., state) = workflow.find_inbound_channel(id);
+                    let state = workflow.inbound_channel(id).unwrap();
                     channel.truncate(state.received_message_count());
                 }
             }

--- a/crates/rt/src/storage/local.rs
+++ b/crates/rt/src/storage/local.rs
@@ -449,12 +449,11 @@ impl WriteWorkflows for LocalTransaction<'_> {
         let mut all_channels = workflows.flat_map(|(record, persisted)| {
             persisted
                 .inbound_channels()
-                .map(move |(_, state)| (record, state))
+                .map(move |(id, state)| (record, id, state))
         });
 
-        all_channels.find_map(|(record, state)| {
+        all_channels.find_map(|(record, channel_id, state)| {
             if state.waits_for_message() {
-                let channel_id = state.id();
                 let next_message_idx = state.received_message_count();
                 let channel = &self.inner.channels[&channel_id];
                 if channel.contains_index(next_message_idx) {

--- a/crates/rt/src/storage/local.rs
+++ b/crates/rt/src/storage/local.rs
@@ -448,7 +448,7 @@ impl WriteWorkflows for LocalTransaction<'_> {
         });
         let mut all_channels = workflows.flat_map(|(record, persisted)| {
             persisted
-                .inbound_channels()
+                .receivers()
                 .map(move |(id, state)| (record, id, state))
         });
 
@@ -526,7 +526,7 @@ impl StorageTransaction for LocalTransaction<'_> {
                         WorkflowState::Active(state) => &state.persisted,
                         WorkflowState::Completed(_) | WorkflowState::Errored(_) => continue,
                     };
-                    let state = workflow.inbound_channel(id).unwrap();
+                    let state = workflow.receiver(id).unwrap();
                     channel.truncate(state.received_message_count());
                 }
             }

--- a/crates/rt/src/storage/mod.rs
+++ b/crates/rt/src/storage/mod.rs
@@ -459,8 +459,8 @@ pub enum WorkflowWaker {
     Internal,
     /// Waker produced by a timer.
     Timer(DateTime<Utc>),
-    /// Waker produced by an outbound channel closure.
-    OutboundChannelClosure(ChannelId),
+    /// Waker produced by a sender closure.
+    SenderClosure(ChannelId),
     /// Waker produced by a completed child workflow.
     ChildCompletion(WorkflowId),
 }

--- a/crates/rt/src/test.rs
+++ b/crates/rt/src/test.rs
@@ -21,19 +21,15 @@
 //! // The module can then be used in tests
 //! ```
 
-use chrono::{DateTime, Utc};
 use externref::processor::Processor;
-use futures::{channel::mpsc, Stream};
 
 use std::{
-    env, fs, ops,
+    env, fs,
     path::{Path, PathBuf},
     process::{Command, Stdio},
-    sync::{Arc, Mutex},
 };
 
-use crate::module::{Clock, Schedule, TimerFuture};
-use tardigrade::test::MockScheduler as SchedulerBase;
+pub use crate::mock_scheduler::MockScheduler;
 
 /// Options for the `wasm-opt` optimizer.
 ///
@@ -230,126 +226,5 @@ impl ModuleCompiler {
                 wasm_file.to_string_lossy()
             )
         })
-    }
-}
-
-/// Mock [wall clock](Clock) and [scheduler](Schedule).
-///
-/// # Examples
-///
-/// A primary use case is to use the scheduler with a [`Driver`] for integration testing:
-///
-/// [`Driver`]: crate::driver::Driver
-///
-/// ```
-/// # use async_std::task;
-/// # use futures::TryStreamExt;
-/// # use tardigrade::{interface::OutboundChannel, spawn::ManageWorkflowsExt};
-/// # use tardigrade_rt::{
-/// #     driver::Driver, manager::{WorkflowHandle, WorkflowManager}, storage::LocalStorage,
-/// #     test::MockScheduler, WorkflowModule,
-/// # };
-/// # async fn test_wrapper(module: WorkflowModule) -> anyhow::Result<()> {
-/// let scheduler = MockScheduler::default();
-/// // Set the mocked wall clock for the workflow manager.
-/// let storage = LocalStorage::default();
-/// let mut manager = WorkflowManager::builder(storage)
-///     .with_clock(scheduler.clone())
-///     .build()
-///     .await?;
-/// let inputs: Vec<u8> = // ...
-/// #   vec![];
-/// let mut workflow = manager
-///     .new_workflow::<()>("test::Workflow", inputs)?
-///     .build()
-///     .await?;
-///
-/// // Spin up the driver to execute the `workflow`.
-/// let mut driver = Driver::new();
-/// let mut handle = workflow.handle();
-/// let mut events_rx = handle.remove(OutboundChannel("events"))
-///     .unwrap()
-///     .into_stream(&mut driver);
-/// task::spawn(async move { driver.drive(&mut manager).await });
-///
-/// // Advance mocked wall clock.
-/// let now = scheduler.now();
-/// scheduler.set_now(now + chrono::Duration::seconds(1));
-/// // This can lead to the workflow progressing, e.g., by emitting messages
-/// let message: Option<Vec<u8>> = events_rx.try_next().await?;
-/// // Assert on `message`...
-/// # Ok(())
-/// # }
-/// ```
-#[derive(Debug, Clone)]
-pub struct MockScheduler {
-    inner: Arc<Mutex<SchedulerBase>>,
-    new_expirations_sx: mpsc::UnboundedSender<DateTime<Utc>>,
-}
-
-impl Default for MockScheduler {
-    fn default() -> Self {
-        Self {
-            inner: Arc::default(),
-            new_expirations_sx: mpsc::unbounded().0,
-        }
-    }
-}
-
-impl MockScheduler {
-    /// Creates a mock scheduler together with a stream that notifies the consumer
-    /// about new timer expirations.
-    pub fn with_expirations() -> (Self, impl Stream<Item = DateTime<Utc>> + Unpin) {
-        let (new_expirations_sx, rx) = mpsc::unbounded();
-        let this = Self {
-            inner: Arc::default(),
-            new_expirations_sx,
-        };
-        (this, rx)
-    }
-
-    fn inner(&self) -> impl ops::DerefMut<Target = SchedulerBase> + '_ {
-        self.inner.lock().unwrap()
-    }
-
-    /// Returns the expiration for the nearest timer, or `None` if there are no active timers.
-    pub fn next_timer_expiration(&self) -> Option<DateTime<Utc>> {
-        self.inner().next_timer_expiration()
-    }
-
-    /// Returns the current timestamp.
-    pub fn now(&self) -> DateTime<Utc> {
-        self.inner().now()
-    }
-
-    /// Sets the current timestamp for the scheduler.
-    pub fn set_now(&self, now: DateTime<Utc>) {
-        self.inner().set_now(now);
-    }
-}
-
-impl Clock for MockScheduler {
-    fn now(&self) -> DateTime<Utc> {
-        self.now()
-    }
-}
-
-impl Schedule for MockScheduler {
-    fn create_timer(&self, expires_at: DateTime<Utc>) -> TimerFuture {
-        use futures::{future, FutureExt};
-
-        let mut guard = self.inner();
-        let now = guard.now();
-        if now >= expires_at {
-            Box::pin(future::ready(now))
-        } else {
-            self.new_expirations_sx.unbounded_send(expires_at).ok();
-            Box::pin(guard.insert_timer(expires_at).then(|res| match res {
-                Ok(timestamp) => future::ready(timestamp).left_future(),
-                Err(_) => future::pending().right_future(),
-                // ^ An error can occur when the mock scheduler is dropped, usually at the end
-                // of a test. In this case the timer never expires.
-            }))
-        }
     }
 }

--- a/crates/rt/src/workflow/mod.rs
+++ b/crates/rt/src/workflow/mod.rs
@@ -1,6 +1,7 @@
 //! `Workflow` and tightly related types.
 
 use anyhow::Context;
+use serde::{Deserialize, Serialize};
 use wasmtime::{AsContextMut, Linker, Store};
 
 use std::{collections::HashMap, mem, sync::Arc};
@@ -18,7 +19,7 @@ use crate::{
     },
     utils::Message,
 };
-use tardigrade::{task::TaskResult, ChannelId, TaskId, WorkflowId};
+use tardigrade::{task::TaskResult, ChannelId, TaskId};
 
 #[derive(Debug, Default)]
 struct ExecutionOutput {
@@ -26,7 +27,8 @@ struct ExecutionOutput {
     task_result: Option<TaskResult>,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[allow(clippy::unsafe_derive_deserialize)] // false positive
 pub(crate) struct ChannelIds {
     pub inbound: HashMap<String, ChannelId>,
     pub outbound: HashMap<String, ChannelId>,
@@ -36,7 +38,7 @@ impl WorkflowSpawner<()> {
     pub(crate) fn spawn<'a>(
         &self,
         raw_args: Vec<u8>,
-        channel_ids: &ChannelIds,
+        channel_ids: ChannelIds,
         services: Services<'a>,
     ) -> anyhow::Result<Workflow<'a>> {
         let state = WorkflowData::new(self.interface(), channel_ids, services);
@@ -249,14 +251,10 @@ impl<'a> Workflow<'a> {
         Ok(())
     }
 
-    pub(crate) fn take_pending_inbound_message(
-        &mut self,
-        workflow_id: Option<WorkflowId>,
-        channel_name: &str,
-    ) -> bool {
+    pub(crate) fn take_pending_inbound_message(&mut self, channel_id: ChannelId) -> bool {
         self.store
             .data_mut()
-            .take_pending_inbound_message(workflow_id, channel_name)
+            .take_pending_inbound_message(channel_id)
     }
 
     #[tracing::instrument(level = "debug", skip(self), ret)]

--- a/crates/rt/src/workflow/mod.rs
+++ b/crates/rt/src/workflow/mod.rs
@@ -1,7 +1,7 @@
 //! `Workflow` and tightly related types.
 
 use anyhow::Context;
-use wasmtime::{AsContextMut, Linker, Store, Trap};
+use wasmtime::{AsContextMut, Linker, Store};
 
 use std::{collections::HashMap, mem, sync::Arc};
 
@@ -117,7 +117,7 @@ impl<'a> Workflow<'a> {
         &mut self,
         function: &ExecutedFunction,
         data: Option<&[u8]>,
-    ) -> Result<ExecutionOutput, Trap> {
+    ) -> anyhow::Result<ExecutionOutput> {
         let mut output = ExecutionOutput::default();
         match function {
             ExecutedFunction::Task { task_id, .. } => {

--- a/crates/rt/src/workflow/mod.rs
+++ b/crates/rt/src/workflow/mod.rs
@@ -30,8 +30,8 @@ struct ExecutionOutput {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[allow(clippy::unsafe_derive_deserialize)] // false positive
 pub(crate) struct ChannelIds {
-    pub inbound: HashMap<String, ChannelId>,
-    pub outbound: HashMap<String, ChannelId>,
+    pub receivers: HashMap<String, ChannelId>,
+    pub senders: HashMap<String, ChannelId>,
 }
 
 impl WorkflowSpawner<()> {

--- a/crates/rt/src/workflow/persistence.rs
+++ b/crates/rt/src/workflow/persistence.rs
@@ -9,8 +9,9 @@ use std::{fmt, task::Poll};
 
 use crate::{
     data::{
-        ChildWorkflowState, ConsumeError, InboundChannelState, OutboundChannelState, PersistError,
-        PersistedWorkflowData, Refs, TaskState, TimerState, Wakers, WorkflowData,
+        ChannelMapping, ChildWorkflowState, ConsumeError, InboundChannelState,
+        OutboundChannelState, PersistError, PersistedWorkflowData, Refs, TaskState, TimerState,
+        Wakers, WorkflowData,
     },
     module::{DataSection, Services, WorkflowSpawner},
     receipt::WakeUpCause,
@@ -206,7 +207,6 @@ impl PersistedWorkflow {
         self.state.close_inbound_channel(channel_id);
     }
 
-    // FIXME: check usage for aliased channels
     #[tracing::instrument(level = "debug", skip(self))]
     pub(crate) fn close_outbound_channel(&mut self, channel_id: ChannelId) {
         self.state.close_outbound_channel(channel_id);
@@ -305,8 +305,9 @@ impl PersistedWorkflow {
         self.state.waker_queue.iter().map(Wakers::cause)
     }
 
-    pub(crate) fn channel_ids(&self) -> &ChannelIds {
-        self.state.channel_ids()
+    // FIXME: make public
+    pub(crate) fn channel_mapping(&self) -> &ChannelMapping {
+        self.state.channel_mapping()
     }
 
     /// Restores a workflow from the persisted state and the `spawner` defining the workflow.

--- a/crates/shared/README.md
+++ b/crates/shared/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/slowli/tardigrade/workflows/CI/badge.svg?branch=main)](https://github.com/slowli/tardigrade/actions)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%2FApache--2.0-blue)](https://github.com/slowli/tardigrade#license)
-![rust 1.60+ required](https://img.shields.io/badge/rust-1.60+-blue.svg?label=Required%20Rust)
+![rust 1.65+ required](https://img.shields.io/badge/rust-1.65+-blue.svg?label=Required%20Rust)
 
 **Documentation:**
 [![crate docs (main)](https://img.shields.io/badge/main-yellow.svg?label=docs)](https://slowli.github.io/tardigrade/tardigrade_shared/)

--- a/e2e-tests/basic/Cargo.toml
+++ b/e2e-tests/basic/Cargo.toml
@@ -44,4 +44,4 @@ rev = "8ee374e08cb702df70d27c9eb7e36f87ff72da6f"
 [dev-dependencies.tardigrade-rt]
 version = "0.1.0"
 path = "../../crates/rt"
-features = ["async-io"]
+features = ["async-io", "test"]

--- a/e2e-tests/basic/src/lib.rs
+++ b/e2e-tests/basic/src/lib.rs
@@ -39,14 +39,14 @@ impl PizzaKind {
     }
 }
 
-/// Orders sent to the workflow via an inbound channel (see [`PizzaDeliveryHandle`]).
+/// Orders sent to the workflow via a channel (see [`PizzaDeliveryHandle`]).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PizzaOrder {
     pub kind: PizzaKind,
     pub delivery_distance: u64,
 }
 
-/// Domain events emitted by the workflow and sent via the corresponding outbound channel.
+/// Domain events emitted by the workflow and sent via the corresponding channel.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DomainEvent {
     OrderTaken { index: usize, order: PizzaOrder },
@@ -73,13 +73,13 @@ pub struct Args {
     pub deliverer_count: usize,
 }
 
-/// Cloneable part of the workflow handle consisting of its outbound channels.
+/// Cloneable part of the workflow handle consisting of its channel senders.
 #[tardigrade::handle]
 // ^ Proc macro that derives some helper traits for the handle.
 #[derive(Debug, Clone)]
 pub struct SharedHandle<Env> {
     // For the proc macro to work, fields need to be defined as `Handle<T, Env>`, where
-    // `T` describes a workflow element (in this case, an outbound channel).
+    // `T` describes a workflow element (in this case, a receiver).
     pub events: Handle<Sender<DomainEvent, Json>, Env>,
 }
 

--- a/e2e-tests/basic/src/spawn.rs
+++ b/e2e-tests/basic/src/spawn.rs
@@ -35,7 +35,7 @@ impl PizzaDeliveryHandle {
                     let builder =
                         Workflows.new_workflow::<Baking>(DEFINITION_ID, (counter, order))?;
                     builder.handle().events.copy_from(events);
-                    // FIXME: add another outbound channel to close?
+                    // FIXME: add another sender to close?
                     let handle = builder.build().await?;
                     handle.workflow.await.map_err(TaskError::from)
                 }

--- a/e2e-tests/basic/tests/integration/async_env.rs
+++ b/e2e-tests/basic/tests/integration/async_env.rs
@@ -18,7 +18,7 @@ use std::{
 
 use crate::LocalManager;
 use tardigrade::{
-    interface::{InboundChannel, OutboundChannel},
+    interface::{ReceiverName, SenderName},
     spawn::ManageWorkflowsExt,
     Decode, Encode, Json, TimerId,
 };
@@ -510,10 +510,10 @@ async fn dynamically_typed_async_handle() -> TestResult {
         .await?;
     let mut handle = workflow.handle();
     let mut env = Driver::new();
-    let orders_sx = handle.remove(InboundChannel("orders")).unwrap();
+    let orders_sx = handle.remove(ReceiverName("orders")).unwrap();
     let orders_id = orders_sx.channel_id();
     let mut orders_sx = orders_sx.into_sink(&mut env);
-    let events_rx = handle.remove(OutboundChannel("events")).unwrap();
+    let events_rx = handle.remove(SenderName("events")).unwrap();
     let events_id = events_rx.channel_id();
     let events_rx = events_rx.into_stream(&mut env);
 
@@ -567,7 +567,7 @@ async fn rollbacks_on_trap() -> TestResult {
     let mut handle = workflow.handle();
     let mut env = Driver::new();
     env.drop_erroneous_messages();
-    let orders_sx = handle.remove(InboundChannel("orders")).unwrap();
+    let orders_sx = handle.remove(ReceiverName("orders")).unwrap();
     let mut orders_sx = orders_sx.into_sink(&mut env);
     let results = env.tick_results();
     let join_handle = spawn_traced_task(async move { env.drive(&mut manager).await });
@@ -580,7 +580,7 @@ async fn rollbacks_on_trap() -> TestResult {
         [
             Ok(_), // initialization
             Err(err), // receiving message
-            Ok(_), // closing inbound channel
+            Ok(_), // closing receiver
         ] => err,
         _ => panic!("unexpected results: {results:#?}"),
     };

--- a/e2e-tests/basic/tests/integration/main.rs
+++ b/e2e-tests/basic/tests/integration/main.rs
@@ -80,14 +80,12 @@ fn enable_tracing_assertions() -> (DefaultGuard, SharedStorage) {
 #[test]
 fn module_information_is_correct() -> TestResult {
     let interfaces: HashMap<_, _> = MODULE.interfaces().collect();
+    assert!(interfaces["PizzaDelivery"].receiver("orders").is_some());
     assert!(interfaces["PizzaDelivery"]
-        .inbound_channel("orders")
-        .is_some());
-    assert!(interfaces["PizzaDelivery"]
-        .inbound_channel("baking_responses")
+        .receiver("baking_responses")
         .is_none());
     assert!(interfaces["PizzaDeliveryWithRequests"]
-        .inbound_channel("baking_responses")
+        .receiver("baking_responses")
         .is_some());
     Ok(())
 }

--- a/e2e-tests/basic/tests/integration/spawn.rs
+++ b/e2e-tests/basic/tests/integration/spawn.rs
@@ -64,7 +64,7 @@ async fn spawning_child_workflows() -> TestResult {
 
     // Check domain events produced by child workflows
     let events: Vec<_> = events_rx.try_collect().await?;
-    assert_eq!(events.len(), orders.len() * 2);
+    assert_eq!(events.len(), orders.len() * 2, "{events:?}");
     for i in 1..=orders.len() {
         let order_events: Vec<_> = events.iter().filter(|event| event.index() == i).collect();
         assert_matches!(

--- a/src/abi.rs
+++ b/src/abi.rs
@@ -13,7 +13,7 @@ use std::{error, fmt, task::Poll};
 
 use crate::{
     error::{HostError, SendError, TaskError},
-    interface::{AccessErrorKind, ChannelKind},
+    interface::{AccessErrorKind, ChannelHalf},
 };
 
 /// Result of polling a receiver end of a channel.
@@ -351,20 +351,20 @@ impl IntoWasm for Result<(), HostError> {
     }
 }
 
-impl TryFromWasm for ChannelKind {
+impl TryFromWasm for ChannelHalf {
     type Abi = i32;
 
     fn into_abi_in_wasm(self) -> Self::Abi {
         match self {
-            Self::Inbound => 0,
-            Self::Outbound => 1,
+            Self::Receiver => 0,
+            Self::Sender => 1,
         }
     }
 
     fn try_from_wasm(abi: Self::Abi) -> Result<Self, FromWasmError> {
         match abi {
-            0 => Ok(Self::Inbound),
-            1 => Ok(Self::Outbound),
+            0 => Ok(Self::Receiver),
+            1 => Ok(Self::Sender),
             _ => Err(FromWasmError::new("unexpected `ChannelKind` value")),
         }
     }

--- a/src/abi.rs
+++ b/src/abi.rs
@@ -30,7 +30,7 @@ impl WasmValue for i64 {}
 /// Simple WASM allocator interface.
 pub trait AllocateBytes {
     /// Allocation error.
-    type Error: error::Error + 'static;
+    type Error: 'static;
 
     /// Copies `bytes` to WASM and returns a (pointer, length) tuple for the copied slice.
     ///

--- a/src/channel/imp_wasm32.rs
+++ b/src/channel/imp_wasm32.rs
@@ -13,7 +13,7 @@ use std::{
 use crate::{
     abi::IntoWasm,
     channel::SendError,
-    interface::{AccessError, AccessErrorKind, InboundChannel, OutboundChannel},
+    interface::{AccessError, AccessErrorKind, ReceiverName, SenderName},
     spawn::imp::RemoteWorkflow,
     workflow::{TakeHandle, Wasm},
 };
@@ -52,7 +52,7 @@ impl TakeHandle<Wasm> for MpscReceiver {
             let resource = mpsc_receiver_get(None, id.as_ptr(), id.len(), &mut ACCESS_ERROR_PAD);
             Result::<(), AccessErrorKind>::from_abi_in_wasm(ACCESS_ERROR_PAD)
                 .map(|()| resource.unwrap().into())
-                .map_err(|kind| kind.with_location(InboundChannel(id)))
+                .map_err(|kind| kind.with_location(ReceiverName(id)))
         }
     }
 }
@@ -91,7 +91,7 @@ extern "C" {
     ) -> Option<Resource<MpscSender>>;
 }
 
-/// Unbounded sender end of an MPSC channel. Guaranteed to never close.
+/// Unbounded sender end of an MPSC channel.
 #[derive(Debug, Clone)]
 pub struct MpscSender {
     resource: Arc<Resource<Self>>,
@@ -120,7 +120,7 @@ impl TakeHandle<Wasm> for MpscSender {
             let resource = mpsc_sender_get(None, id.as_ptr(), id.len(), &mut ACCESS_ERROR_PAD);
             Result::<(), AccessErrorKind>::from_abi_in_wasm(ACCESS_ERROR_PAD)
                 .map(|()| resource.unwrap().into())
-                .map_err(|kind| kind.with_location(OutboundChannel(id)))
+                .map_err(|kind| kind.with_location(SenderName(id)))
         }
     }
 }

--- a/src/channel/requests.rs
+++ b/src/channel/requests.rs
@@ -139,7 +139,7 @@ impl<Req, Resp> RequestsHandle<Req, Resp> {
 ///
 /// # Examples
 ///
-/// `Requests` instance can be built from a pair of inbound / outbound channels:
+/// `Requests` instance can be built from a pair of sender / receiver channel halves:
 ///
 /// ```
 /// # use async_trait::async_trait;

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -7,7 +7,7 @@ use std::{convert::Infallible, error};
 /// When used in workflows (e.g., in [`Receiver`]), [`Self::decode_bytes()`] method
 /// is used. That is, decoding operations panic if an error occurs during decoding. This is usually
 /// the intended behavior, since the primary reason of such a panic would be an incorrect input
-/// supplied via arguments or an inbound channel. The workflow runtime is expected to roll back
+/// supplied via arguments or a channel receiver. The workflow runtime is expected to roll back
 /// the workflow state in this case.
 ///
 /// [`Receiver`]: crate::channel::Receiver

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! Timers [can be created dynamically](sleep) during workflow operation; likewise, tasks
 //! can be [`spawn()`](task::spawn())ed to achieve concurrency (but not parallelism!).
-//! In contrast, the set of channels and their direction (inbound or outbound)
+//! In contrast, the set of channel halves and their direction (receiver or sender)
 //! are static / predefined in the workflow [`Interface`].
 //!
 //! A workflow is sandboxed by the virtue of being implemented as a WASM module.
@@ -112,8 +112,8 @@ pub use crate::{
 /// #[tardigrade::handle]
 /// #[derive(Debug)]
 /// pub struct MyHandle<Env> {
-///     pub inbound: Handle<Receiver<i64, Json>, Env>,
-///     pub outbound: Handle<Sender<i64, Json>, Env>,
+///     pub receiver: Handle<Receiver<i64, Json>, Env>,
+///     pub sender: Handle<Sender<i64, Json>, Env>,
 /// }
 /// ```
 ///

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -18,9 +18,9 @@
 //! #[tardigrade::handle]
 //! #[derive(Debug)]
 //! pub struct MyHandle<Env = Wasm> {
-//!     /// Inbound channel with commands.
+//!     /// Receiver for commands.
 //!     pub commands: Handle<Receiver<Command, Json>, Env>,
-//!     /// Outbound channel with events.
+//!     /// Sender for events.
 //!     pub events: Handle<Sender<Event, Json>, Env>,
 //! }
 //!
@@ -328,18 +328,15 @@ impl Wasm {
         Self { handles }
     }
 
-    pub(crate) fn take_inbound_channel(
+    pub(crate) fn take_receiver(
         &mut self,
         channel_name: &str,
     ) -> Option<crate::channel::RawReceiver> {
-        self.handles.inbound_channels.remove(channel_name)
+        self.handles.receivers.remove(channel_name)
     }
 
-    pub(crate) fn take_outbound_channel(
-        &mut self,
-        channel_name: &str,
-    ) -> Option<crate::channel::RawSender> {
-        self.handles.outbound_channels.remove(channel_name)
+    pub(crate) fn take_sender(&mut self, channel_name: &str) -> Option<crate::channel::RawSender> {
+        self.handles.senders.remove(channel_name)
     }
 }
 


### PR DESCRIPTION
Resolves some of the accumulated tech debt:

- Update dependencies (`wasmtime`, `mimicry`)
- Key channel states by channel ID, rather than by the containing interface
- Use "receiver" / "sender" instead of "inbound" / "outbound" channel